### PR TITLE
Improvements for CI Testing

### DIFF
--- a/.github/workflows/litevm.yml
+++ b/.github/workflows/litevm.yml
@@ -24,10 +24,14 @@ jobs:
     strategy:
       matrix:
         # OL7 and OL8 use 3.6. OL9 uses 3.9. Also test on the latest.
-        python-version: ["3.6", "3.9", "3.12"]
+        python-minor: ["6", "9", "12"]
       fail-fast: false
     env:
-      TOX_OVERRIDE: "tox.envlist=python${{ matrix.python-version }};tox.skip_missing_interpreters=false"
+      # Manually set the tox environment list to the Python version.
+      # As a result, we should set "skip missing interpreters" to false,
+      # so that we fail if the test doesn't run.
+      TOX_OVERRIDE: "tox.envlist=py3${{ matrix.python-minor }}"
+      TOX_SKIP_MISSING_INTERPRETERS: "false"
     steps:
       - uses: actions/checkout@v4
       # If we rely on using the same Python version for tox as we do for the
@@ -42,7 +46,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.${{ matrix.python-minor }}
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -51,8 +55,10 @@ jobs:
           echo '0403da24a797ccfa0cfd37bd4a6d6049370b9773e558da6173ae6ad25f97a428 /usr/bin/rpm2cpio' | sha256sum -c -
           sudo chmod 755 /usr/bin/rpm2cpio
       - name: Setup test environment
+        # Pinned virtualenv and tox are for the last versions which support
+        # detecting Python 3.6 and running tests on it.
         run: |
-          python3.12 -m pip install --user --break-system-packages tox
+          python3.12 -m pip install --user --break-system-packages 'virtualenv<20.22.0' 'tox<4.5.0'
           tox list
           tox --notest
           tox -e runner --notest
@@ -88,4 +94,4 @@ jobs:
 
       - name: Run tests
         run: |
-          tox -e runner -- python -m testing.litevm.vm --python-version ${{ matrix.python-version }}
+          tox -e runner -- python -m testing.litevm.vm --python-version 3${{ matrix.python-minor }}

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,6 @@ litevm-test:
 .PHONY: vmcore-test
 vmcore-test:
 	-tox -e runner -- python -m testing.vmcore test
-	@cp '.tox/runner/log/2-commands[0].log' test-vmcore.log
-	@echo 'View the test log files: "less -R test-vmcore.log"'
 
 
 test: litevm-test vmcore-test

--- a/testing/README.md
+++ b/testing/README.md
@@ -120,8 +120,8 @@ Requirements:
 
 - Qemu, and the qemu disk utils (see oddities for Oracle Linux info)
 - `wget`
-- `isoinfo` from the `genisoimage` package
-- mtools (FAT filesystem in userspace)
+- `7z` from the `p7zip-plugins` package
+- `mtools` package (FAT filesystem in userspace)
 - Quite a bit of time to build the VMs, and disk space to store them
 
 Test data:

--- a/testing/README.md
+++ b/testing/README.md
@@ -121,7 +121,6 @@ Requirements:
 - Qemu, and the qemu disk utils (see oddities for Oracle Linux info)
 - `wget`
 - `7z` from the `p7zip-plugins` package
-- `mtools` package (FAT filesystem in userspace)
 - Quite a bit of time to build the VMs, and disk space to store them
 
 Test data:

--- a/testing/heavyvm/runner.py
+++ b/testing/heavyvm/runner.py
@@ -17,8 +17,8 @@ from testing.heavyvm.qemu import create_overlay_disk
 from testing.heavyvm.qemu import QemuRunner
 from testing.heavyvm.qemu import UnixSocketRepl
 from testing.util import BASE_DIR
-from testing.util import gitlab_section_end
-from testing.util import gitlab_section_start
+from testing.util import ci_section_end
+from testing.util import ci_section_start
 
 
 @dataclasses.dataclass
@@ -93,10 +93,10 @@ class TestRunner:
     def _section_start(
         self, name: str, text: str, collapsed: bool = False
     ) -> None:
-        gitlab_section_start(name, text, collapsed=collapsed)
+        ci_section_start(name, text, collapsed=collapsed)
 
     def _section_end(self, name: str) -> None:
-        gitlab_section_end(name)
+        ci_section_end(name)
 
     def _launch_vms(self) -> None:
         self._section_start("launch_vms", "Launching VMs", collapsed=True)

--- a/testing/litevm/vm.py
+++ b/testing/litevm/vm.py
@@ -24,6 +24,7 @@ from testing.litevm.rpm import extract_rpms
 from testing.litevm.rpm import TEST_KERNELS
 from testing.litevm.rpm import TestKernel
 from testing.util import BASE_DIR
+from testing.util import ci_section
 
 
 INITRD_DIRS = [
@@ -402,7 +403,10 @@ def main():
         k.cache_dir = args.yum_cache_dir
         if args.kernel and not fnmatch.fnmatch(k.slug(), args.kernel):
             continue
-        run_vm(k, args.extract_dir, commands)
+        section_name = f"uek{k.uek_ver}"
+        section_text = f"Run tests on UEK{k.uek_ver}"
+        with ci_section(section_name, section_text):
+            run_vm(k, args.extract_dir, commands)
 
 
 if __name__ == "__main__":

--- a/testing/util.py
+++ b/testing/util.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 import os
-import sys
 import time
 from contextlib import contextmanager
 from pathlib import Path
@@ -22,26 +21,27 @@ def gitlab_section_start(
     """
     if collapsed:
         name += "[collapsed=true]"
-    print(f"\x1b[0Ksection_start:{int(time.time())}:{name}\r\x1b[0K{text}")
-    sys.stdout.flush()
+    print(
+        f"\x1b[0Ksection_start:{int(time.time())}:{name}\r\x1b[0K{text}",
+        flush=True,
+    )
 
 
 def gitlab_section_end(name: str) -> None:
     """
     Close the section for gitlab CI output.
     """
-    print(f"\x1b[0Ksection_end:{int(time.time())}:{name}\r\x1b[0K")
-    sys.stdout.flush()
+    print(f"\x1b[0Ksection_end:{int(time.time())}:{name}\r\x1b[0K", flush=True)
 
 
 def github_section_start(
     name: str, text: str, collapsed: bool = False
 ) -> None:
-    print(f"::group::{text}")
+    print(f"::group::{text}", flush=True)
 
 
 def github_section_end(name: str) -> None:
-    print("::endgroup::")
+    print("::endgroup::", flush=True)
 
 
 if os.environ.get("GITHUB_ACTIONS"):

--- a/testing/util.py
+++ b/testing/util.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+import os
 import sys
 import time
 from contextlib import contextmanager
@@ -33,18 +34,39 @@ def gitlab_section_end(name: str) -> None:
     sys.stdout.flush()
 
 
+def github_section_start(
+    name: str, text: str, collapsed: bool = False
+) -> None:
+    print(f"::group::{text}")
+
+
+def github_section_end(name: str) -> None:
+    print("::endgroup::")
+
+
+if os.environ.get("GITHUB_ACTIONS"):
+    ci_section_start = github_section_start
+    ci_section_end = github_section_end
+elif os.environ.get("GITLAB_CI"):
+    ci_section_start = gitlab_section_start
+    ci_section_end = gitlab_section_end
+else:
+
+    def ci_section_start(
+        name: str, text: str, collapsed: bool = False
+    ) -> None:
+        pass
+
+    def ci_section_end(name: str) -> None:
+        pass
+
+
 @contextmanager
-def gitlab_section(
-    name: str,
-    text: str,
-    collapsed: bool = False,
+def ci_section(
+    name: str, text: str, collapsed: bool = False
 ) -> Generator[None, None, None]:
-    """
-    Return a context manager that starts a section on entry, and ends it on
-    exit.
-    """
-    gitlab_section_start(name, text, collapsed=collapsed)
+    ci_section_start(name, text, collapsed=collapsed)
     try:
         yield
     finally:
-        gitlab_section_end(name)
+        ci_section_end(name)

--- a/testing/vmcore.py
+++ b/testing/vmcore.py
@@ -29,7 +29,7 @@ from rich.progress import TextColumn
 from rich.progress import TimeRemainingColumn
 from rich.progress import TransferSpeedColumn
 
-from testing.util import gitlab_section
+from testing.util import ci_section
 
 CORE_DIR = Path.cwd() / "testdata/vmcores"
 
@@ -240,7 +240,7 @@ def upload_all(client: ObjectStorageClient, core: str) -> None:
 def test() -> None:
     for path in CORE_DIR.iterdir():
         core_name = path.name
-        with gitlab_section(
+        with ci_section(
             f"vmcore-{core_name}",
             f"Running tests on vmcore {core_name}",
             collapsed=True,

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     pytest-cov
 commands =
     python -m pytest --cov=drgn_tools --cov=tests -rP {posargs}
-passenv = DRGNTOOLS_*
+passenv = DRGNTOOLS_*, GITLAB_CI, GITHUB_ACTIONS
 
 [testenv:docs]
 deps =
@@ -27,7 +27,7 @@ commands = sphinx-build -d "{toxworkdir}/docs_doctree" doc "{toxworkdir}/docs_ou
 deps =
     -r testing/requirements.txt
 commands = {posargs}
-passenv = VMCORE_*
+passenv = VMCORE_*, GITLAB_CI, GITHUB_ACTIONS
 
 [flake8]
 max-line-length = 80

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 [tox]
-envlist = py3.6,py3.7,py3.8,py3.9,py3.10,py3.11
+envlist = py36,py37,py38,py39,py310,py311
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
This pull request incorporates several improvements for CI testing:

1. The tox environment names I established for Github Actions (`py3.6`, ...) don't seem to be correct. They need to have names like `py36` in order to work correctly. So, the first commit changes the names of these environments and makes the necessary changes for the Github Actions workflow to use those names instead. This makes Github Actions choose the correct Python version, and it also improves the very slow CI test runtimes we've seen on Gitlab CI.
2. Test output is very cluttered, and the test runner for Gitlab had the ability to split it into collapsible sections. I've added support to do this for Github too, and now the litevm test runner uses collapsible sections to help organize output.
3. I've been going through the developer workflow documentation to ensure everything works, so there are a couple tweaks to the Makefile and the heavyvm testing to make everything work correctly. There are actually quite a few updates to the heavyvm testing which simplify the dependencies and make sure everything works on OL9.