### PR TITLE
drgn-tools: full aarch64 support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,8 +2,7 @@ vmtest:
   script:
     - rm -rf .tox
     - git archive HEAD -o archive.tar.gz
-    - python3.8 -m venv venv
-    - venv/bin/pip install -r testing/requirements.txt
-    - venv/bin/python -m testing.vmcore test --core-directory /var/drgn-tools/vmcores
+    - tox -e runner --notest
+    - tox -e runner -- python -m testing.vmcore test --core-directory /var/drgn-tools/vmcores
     - mkdir -p tmp/overlays tmp/info
-    - PATH=/usr/local/bin:$PATH venv/bin/python -m testing.heavyvm.runner --image-dir /var/drgn-tools/images --vm-info-dir tmp/info --overlay-dir tmp/overlays --tarball archive.tar.gz
+    - tox -e runner -- python -m testing.heavyvm.runner --image-dir /var/drgn-tools/images --vm-info-dir tmp/info --overlay-dir tmp/overlays --tarball archive.tar.gz

--- a/drgn_tools/mm.py
+++ b/drgn_tools/mm.py
@@ -445,10 +445,9 @@ def totalram_pages(prog: drgn.Program) -> drgn.Object:
     return prog["totalram_pages"]
 
 
-def check_freelists_at_crashing_cpu(prog: drgn.Program) -> None:
-    crashing_cpu = prog["crashing_cpu"].value_()
+def check_freelists_at_cpu(prog: drgn.Program, cpu: int) -> None:
     for slab_cache in for_each_slab_cache(prog):
-        cpu_slab = per_cpu_ptr(slab_cache.cpu_slab.read_(), crashing_cpu)
+        cpu_slab = per_cpu_ptr(slab_cache.cpu_slab.read_(), cpu)
         if cpu_slab.freelist.value_():
             try:
                 _ = prog.read(cpu_slab.freelist.value_(), 1)
@@ -457,7 +456,7 @@ def check_freelists_at_crashing_cpu(prog: drgn.Program) -> None:
                     slab_cache.name.string_(), escape_backslash=True
                 )
                 print(
-                    f"found freelist corruption in lockless freelist of slab-cache: {slab_cache_name} at crash cpu: {crashing_cpu}"
+                    f"found freelist corruption in lockless freelist of slab-cache: {slab_cache_name} at cpu: {cpu}"
                 )
                 return
 

--- a/tests/test_mm.py
+++ b/tests/test_mm.py
@@ -116,5 +116,9 @@ def test_AddrKind_categorize_module_percpu(prog: drgn.Program) -> None:
 
 
 @pytest.mark.skip_live
-def test_check_freelists_at_crashing_cpu(prog: drgn.Program) -> None:
-    mm.check_freelists_at_crashing_cpu(prog)
+def test_check_freelists_at_cpu(prog: drgn.Program) -> None:
+    if "crashing_cpu" in prog:
+        cpu = prog["crashing_cpu"].value_()
+    else:
+        cpu = prog["panic_cpu"].counter.value_()
+    mm.check_freelists_at_cpu(prog, cpu)


### PR DESCRIPTION
We've begun adding helpers which nominally support aarch64, and we're also being better about guarding our x86_64 specific code with architecture checks. This is good, but some of the older drgn-tools code still needed changes. The major thing here is adding the virtual memory map for aarch64, which underpins a lot of useful things like detecting whether an address is a module, text, data, direct-map, vmalloc, vmemmap, etc.

This PR makes those changes. I've added some vmcores to our vmcore test library which were generated on an aarch64 VM. The test suite passes on these vmcores!