### PR TITLE
Corelens module: dentrycache

### DIFF
--- a/drgn_tools/dentry.py
+++ b/drgn_tools/dentry.py
@@ -358,6 +358,12 @@ class DentryCache(CorelensModule):
             action="store_true",
             help="list negative dentries only, disabled by default",
         )
+        parser.add_argument(
+            "--detailed",
+            "-d",
+            action="store_true",
+            help="include inode, super, file type, refcount",
+        )
 
     def run(self, prog: Program, args: argparse.Namespace) -> None:
         if args.negative:
@@ -368,4 +374,10 @@ class DentryCache(CorelensModule):
         if args.limit:
             dentries = take(args.limit, dentries)
 
-        print_dentry_table(dentries)
+        if args.detailed:
+            print_dentry_table(dentries)
+        else:
+            # Emulate oled dentrycache
+            for i, dentry in enumerate(dentries):
+                path = dentry_path_any_mount(dentry).decode()
+                print(f"{i:05d} {path}")

--- a/drgn_tools/dentry.py
+++ b/drgn_tools/dentry.py
@@ -17,7 +17,7 @@ from drgn.helpers.linux.list import list_for_each_entry
 from drgn_tools.corelens import CorelensModule
 from drgn_tools.itertools import count
 from drgn_tools.itertools import take
-from drgn_tools.table import print_table
+from drgn_tools.table import print_row
 
 
 MNT_INTERNAL = 0x4000
@@ -222,32 +222,36 @@ def print_dentry_table(
     :param dentries: Any iterable of ``struct dentry *``
     """
     if refcount:
-        dentry_table = [
-            ["DENTRY", "SUPER_BLOCK", "INODE", "REFCOUNT", "TYPE", "PATH"]
-        ]
+        col_widths = [16] * 3 + [5, 4, 0]
+        print_row(
+            ["DENTRY", "SUPER_BLOCK", "INODE", "REFCOUNT", "TYPE", "PATH"],
+            col_widths,
+        )
     else:
-        dentry_table = [["DENTRY", "SUPER_BLOCK", "INODE", "TYPE", "PATH"]]
+        col_widths = [16] * 3 + [4, 0]
+        print_row(
+            ["DENTRY", "SUPER_BLOCK", "INODE", "TYPE", "PATH"], col_widths
+        )
     for d in dentries:
         file_type = __file_type(int(d.d_inode.i_mode)) if d.d_inode else "NONE"
         if refcount:
-            dentry_stats = [
-                hex(d.value_()),
-                hex(d.d_sb.value_()),
-                hex(d.d_inode.value_()),
-                int(d_count(d)),
+            row = [
+                f"{d.value_():016x}",
+                f"{d.d_sb.value_():016x}",
+                f"{d.d_inode.value_():016x}",
+                str(int(d_count(d))),
                 file_type,
                 dentry_path_any_mount(d).decode(),
             ]
         else:
-            dentry_stats = [
-                hex(d.value_()),
-                hex(d.d_sb.value_()),
-                hex(d.d_inode.value_()),
+            row = [
+                f"{d.value_():016x}",
+                f"{d.d_sb.value_():016x}",
+                f"{d.d_inode.value_():016x}",
                 file_type,
                 dentry_path_any_mount(d).decode(),
             ]
-        dentry_table.append(dentry_stats)  # type: ignore
-    print_table(dentry_table)
+        print_row(row, col_widths)
 
 
 def dentry_is_used(dentry: Object) -> bool:

--- a/drgn_tools/table.py
+++ b/drgn_tools/table.py
@@ -7,6 +7,27 @@ from typing import List
 from typing import Optional
 
 
+def print_row(fields: List[Any], col_widths: List[int]):
+    """
+    Print a single row of a table, given pre-determined column widths
+
+    Note that this doesn't guarantee that the width of every field in the row
+    will be less than the width of the column: in that case, the field's full
+    contents will be printed and columns will be misaligned. For guaranteed
+    aligned columns, see print_table(), or be very careful about your column
+    widths.
+
+    :param fields: a list of fields to print
+    :param col_widths: the width of each field (not including spaces)
+    """
+    print(
+        "  ".join(
+            str(val) if w <= 0 else str(val).ljust(w)
+            for val, w in zip(fields, col_widths)
+        )
+    )
+
+
 def print_table(
     fields: List[List[Any]],
     outfile: Optional[str] = None,


### PR DESCRIPTION
We already have some excellent dentry helpers, but no actual corelens module. This PR adds the corelens module, and it adds a bit of optimization so that the runtime is pretty decent.

1. Add the corelens module.
2. Create a `dentry_path_any_mount()` helper to ensure we get a full path to the root for each dentry.
3. Stop loading dentries into memory when we're printing them out, this ensures we can scale to millions of dentries without any issue.
4. Try to match the `oled dentrycache` output by default.
5.  Improve performance by iterating over the dentry hash table in chunks, rather than one entry at a time.