### PR TITLE
ext4_dirlock: show cached files under the dir

### DIFF
--- a/drgn_tools/ext4_dirlock.py
+++ b/drgn_tools/ext4_dirlock.py
@@ -90,11 +90,13 @@ import drgn
 from drgn import Object
 from drgn import Program
 from drgn.helpers.linux.fs import d_path
+from drgn.helpers.linux.list import list_for_each
 from drgn.helpers.linux.sched import task_state_to_char
 
 from drgn_tools.bt import bt
 from drgn_tools.bt import bt_has
 from drgn_tools.corelens import CorelensModule
+from drgn_tools.itertools import count
 from drgn_tools.locking import for_each_mutex_waiter
 from drgn_tools.locking import for_each_rwsem_waiter
 from drgn_tools.module import ensure_debuginfo
@@ -177,6 +179,10 @@ def ext4_dirlock_scan(prog: drgn.Program, stacktrace: bool = False) -> None:
         print("%-12s: 0x%x" % ("inode", inode.value_()))
         print("%-12s: %d" % ("Size", inode.i_size.value_()))
         print("%-12s: %d" % ("Blocks", inode.i_blocks.value_()))
+        print(
+            "%-12s: %d"
+            % ("subdirs", count(list_for_each(dentry.d_subdirs.address_of_())))
+        )
         print(
             "%-12s: %-16s %-8s %-6s %-16s"
             % ("Inode Lock", "Command", "Pid", "Status", "Lastrun2now")


### PR DESCRIPTION
It tells how many cached files under the dir, a small number doesn't mean iterating the dir will be fast, the size of the dir will be more accurate to tell that since ext4 may not release dir block even all files in that block were removed.