### PR TITLE
Add block-info module

### DIFF
--- a/tests/test_blockinfo.py
+++ b/tests/test_blockinfo.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+from drgn_tools import block
+
+
+def test_blockinfo(prog):
+    block.print_block_devs_info(prog)


### PR DESCRIPTION
block-info prints scsihosts, scsi-device information and pending in-flight IOs

Authored-by: Gulam Mohamed <gulam.mohamed@oracle.com>
Co-authored-by: Srivathsa Dara <srivathsa.d.dara@oracle.com>