### PR TITLE
debuginfo: Fix Python 3.6 compatibility

### DIFF
--- a/drgn_tools/debuginfo.py
+++ b/drgn_tools/debuginfo.py
@@ -192,7 +192,7 @@ class OracleLinuxYumFetcher(DebuginfoFetcher):
             path = Path(f.name)
             if self.rpm_cache:
                 cached.parent.mkdir(exist_ok=True, parents=True)
-                shutil.move(path, cached)
+                shutil.move(str(path), str(cached))
                 path.touch()  # prevent error in unlink
                 path = cached
             return extract_rpm(path, out_dir, modules)


### PR DESCRIPTION
Path arguments to shutil.move are not allowed until Python 3.9.