### PR TITLE
dm: add dmsetup table support for linear target

### DIFF
--- a/drgn_tools/block.py
+++ b/drgn_tools/block.py
@@ -59,6 +59,26 @@ def blkdev_ro(bdev: Object) -> bool:
     return bdev.bd_part.policy != 0
 
 
+def blkdev_name(bdev: Object) -> str:
+    """
+    Return block device name
+
+    :param bdev: ``struct block_device *``
+    :returns: device name
+    """
+    if has_member(bdev, "bd_partno"):
+        partno = int(bdev.bd_partno)
+    else:
+        partno = int(bdev.bd_part.partno)
+
+    disk_name = bdev.bd_disk.disk_name.string_().decode()
+    if partno == 0:
+        return disk_name
+    if disk_name[len(disk_name) - 1].isdigit():
+        return disk_name + "p" + str(partno)
+    return disk_name + str(partno)
+
+
 def for_each_request_queue(prog: drgn.Program) -> Iterable[Object]:
     """
     List all request_queue in the system.


### PR DESCRIPTION
Here is an example of the output:

  >>> dm.show_dm_table(prog)
  ocivolume-oled: 0 20971520 linear 8:3 [sda3] 2048
  ocivolume-root: 0 60940288 linear 8:3 [sda3] 20973568

I would like this gets reviewed/merged before multipath pull request, there were multiple generic dm helpers that can be reused by multipath helpers.

Only linear mapping is supported, i would like support multipath target after multipath helpers get merged, also i may add snapshot target support in future.