### PR TITLE
General fixes & improvements from recent development

### DIFF
--- a/drgn_tools/debuginfo.py
+++ b/drgn_tools/debuginfo.py
@@ -567,12 +567,15 @@ def extract_rpm(
                 continue
             # standardize the names to use underscore
             name = file_path.name.replace("-", "_")
+            dst = dest_dir / name
             # pathlib rename does not work since this is likely to be across
             # filesystems. Use shutil, and use a str() because shutil.move()
             # only got support for handling Path objects in 3.9.
+            if dst.exists():
+                dst.unlink()
             shutil.move(
                 str(file_path),
-                str(dest_dir / name),
+                str(dst),
             )
             if file_path.name == "vmlinux":
                 extracted.append(name)

--- a/drgn_tools/dentry.py
+++ b/drgn_tools/dentry.py
@@ -364,8 +364,8 @@ class DentryCache(CorelensModule):
             "--limit",
             "-l",
             type=int,
-            default=10000,
-            help="list at most <number> dentries, 10000 by default",
+            default=50,
+            help="list at most <number> dentries, 50 by default",
         )
         parser.add_argument(
             "--negative",

--- a/drgn_tools/module.py
+++ b/drgn_tools/module.py
@@ -15,6 +15,7 @@ from drgn import cast
 from drgn import IntegerLike
 from drgn import Object
 from drgn import Program
+from drgn import sizeof
 from drgn import Symbol
 from drgn import SymbolBinding
 from drgn import SymbolKind
@@ -347,7 +348,7 @@ def decode_param(kp: Object) -> ParamInfo:
         type_ = prog.type(_MOD_PARAM_TYPES[elem_type])
         elem_type = elem_type[len(PREFIX) :]
         param_type = f"{elem_type}[{length}]"
-        if type_.size != kp.arr.elemsize:
+        if sizeof(type_) != kp.arr.elemsize:
             return ParamInfo(name, kp, param_type, None)
         obj = Object(prog, prog.array_type(type_, length), address=kp.arr.elem)
     else:

--- a/drgn_tools/table.py
+++ b/drgn_tools/table.py
@@ -58,7 +58,7 @@ def print_table(
             "".join(
                 str(val).ljust(col_width + 2)
                 for (val, col_width) in zip(entry, col_widths)
-            ),
+            ).strip(),
             file=out,
         )
 


### PR DESCRIPTION
This is a bit of a combination of changes which I believe are well explained in their commit messages, but going in order:

* A permissions fix for debuginfo extraction
* Add the filecache corelens command (the code already existed for much of it, just not the `CorelensModule` implementation)
* Address bad performance for `corelens` command on exadata - the `have_debuginfo()` function was quite slow.
* Fix a bug in type sizes.
* The `print_table()` function was printing a bunch of extra spaces at the end of wide tables, which wastes data and also results in the terminal "wrapping" table rows with blank lines.
* Reduced the default count for dentrycache to dump, this makes things a bit less bothersome when running on the CLI.