### PR TITLE
Corelens CLI updates

### DIFF
--- a/drgn_tools/corelens.py
+++ b/drgn_tools/corelens.py
@@ -336,7 +336,7 @@ def _run_module(
     """
     try:
         if to_stdout:
-            print(f"====== MODULE {mod.name} ======")
+            print(f"\n====== MODULE {mod.name} ======")
         mod.run(prog, args)
     except Exception:
         formatted = traceback.format_exc()

--- a/drgn_tools/smp.py
+++ b/drgn_tools/smp.py
@@ -347,5 +347,7 @@ class SmpIpiModule(CorelensModule):
 
     name = "smp"
 
+    live_ok = False
+
     def run(self, prog: Program, args: argparse.Namespace) -> None:
         dump_smp_ipi_state(prog)


### PR DESCRIPTION
These are the corelens CLI tweaks we've been discussing at recent meetings:
- stop defaulting to /proc/kcore
- print usage when no arguments are given, "sysinfo" when just a vmcore is given
- automatically detect and load CTF if no DWARF debuginfo is available
- formatting fix

There's also newly added logic for determining whether modules should run:

- `skip_live` is used on corelens modules which are really only meant for vmcores, not live systems
- `run_when` can be set to three values:
  - `always` in order to run in any report (`-a` or `-A`)
  - `verbose` to only run in the verbose report (`-A)
  - `never` if the module is only intended to be run manually via the CLI (e.g. `corelens /proc/kcore -M module`)