### PR TITLE
Add test runner for testing installed drgn RPM

### DIFF
--- a/.header.txt
+++ b/.header.txt
@@ -1,2 +1,2 @@
-# Copyright (c) 2023, Oracle and/or its affiliates.
+# Copyright (c) 2024, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/

--- a/drgn_tools/md.py
+++ b/drgn_tools/md.py
@@ -239,8 +239,14 @@ def show_raid1_info(prog: Program, mddev: Object) -> None:
     )
     print("%-10s: %d" % ("pending-io", raid1_nr_value(conf.nr_pending)))
     pending_count = conf.pending_count
-    max_queued_requests = prog["max_queued_requests"]
-    congested = True if pending_count >= max_queued_requests else False
+    max_queued_requests = None
+    try:
+        max_queued_requests = prog["max_queued_requests"]
+        congested = pending_count >= max_queued_requests
+    except KeyError:
+        # 9a3abe191fd6 ("md: drop queue limitation for RAID1 and RAID10")
+        # removes this variable, only report if it exists
+        congested = False
     if congested:
         msg = (
             "%-10s: Yes, processes will be stuck when issuing write io."
@@ -253,10 +259,11 @@ def show_raid1_info(prog: Program, mddev: Object) -> None:
         "%-10s: %d writes queued for raid1 thread to handle"
         % (" ", pending_count)
     )
-    print(
-        "%-10s: max allowed queued requests are %d"
-        % (" ", max_queued_requests)
-    )
+    if max_queued_requests is not None:
+        print(
+            "%-10s: max allowed queued requests are %d"
+            % (" ", max_queued_requests)
+        )
 
 
 def show_md(prog: Program) -> None:

--- a/testing/rpm.py
+++ b/testing/rpm.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2024, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+"""
+Simple test runner for built RPMs
+
+Once the drgn and drgn-tools RPMs are built, these automatic tests can be run.
+Be sure to first install "pytest<7.1 pytest-cov" to the system or user.
+"""
+import argparse
+import fnmatch
+import os
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import List
+
+
+CORE_DIR = Path.cwd() / "testdata/vmcores"
+
+
+def vmcore_test(vmcore: str, ctf: bool = False, coverage: bool = False) -> str:
+    ctf_path = CORE_DIR / vmcore / "vmlinux.ctfa"
+    if ctf and not ctf_path.exists():
+        return "skip (CTF not available)"
+
+    return do_test(
+        vmcore,
+        [
+            "--vmcore",
+            vmcore,
+            f"--vmcore-dir={str(CORE_DIR)}",
+        ],
+        ctf=ctf,
+        coverage=coverage,
+    )
+
+
+def do_test(
+    ident: str, args: List[str], ctf: bool = False, coverage: bool = False
+) -> str:
+    kind = "CTF" if ctf else "DWARF"
+    print("=" * 30 + f" TESTING {ident} W/ {kind} " + "=" * 30)
+
+    cmd = [
+        "python3",
+        "-m",
+        "pytest",
+    ]
+    if coverage:
+        cmd += [
+            "--cov=drgn_tools",
+            "--cov-append",
+        ]
+    if ctf:
+        cmd.append("--ctf")
+
+    cmd += args
+    res = subprocess.run(cmd, check=False)
+    if res.returncode != 0:
+        return "fail"
+    else:
+        return "pass"
+
+
+def live_test(ctf: bool = False, coverage: bool = False) -> str:
+    release = os.uname().release
+    kind = "CTF" if ctf else "DWARF"
+    if ctf:
+        path = f"/lib/modules/{release}/kernel/vmlinux.ctfa"
+    else:
+        path = f"/usr/lib/debug/lib/modules/{release}/vmlinux"
+    if not os.path.exists(path):
+        return f"skip ({kind} not available)"
+    return do_test("LIVE", [], ctf=ctf, coverage=coverage)
+
+
+def main() -> None:
+    global CORE_DIR
+
+    parser = argparse.ArgumentParser(description="simple test runner")
+    parser.add_argument(
+        "--no-ctf",
+        dest="ctf",
+        action="store_false",
+        help="do not run CTF tests",
+    )
+    parser.add_argument(
+        "--no-dwarf",
+        dest="dwarf",
+        action="store_false",
+        help="do not run DWARF tests",
+    )
+    parser.add_argument(
+        "--no-live",
+        dest="live",
+        action="store_false",
+        help="do not run live kernel test",
+    )
+    parser.add_argument(
+        "--coverage",
+        action="store_true",
+        help="run code coverage (requires pytest-cov)",
+    )
+    parser.add_argument(
+        "--xml",
+        action="store_true",
+        help="collect output in XML (requires junitparser)",
+    )
+    parser.add_argument(
+        "--core-dir",
+        type=Path,
+        default=CORE_DIR,
+        help="core directory (default: ./testdata/vmcores)",
+    )
+    parser.add_argument(
+        "cores",
+        nargs="*",
+        help="vmcore(s) to run - fnmatch pattern accepted",
+    )
+    args = parser.parse_args()
+    CORE_DIR = args.core_dir
+    cores = [
+        p.name
+        for p in CORE_DIR.iterdir()
+        if p.is_dir() and (p / "vmcore").is_file()
+    ]
+
+    def should_run_vmcore(name: str) -> bool:
+        if not args.cores:
+            return True
+        for pat in args.cores:
+            if fnmatch.fnmatch(name, pat):
+                return True
+        return False
+
+    cores = list(filter(should_run_vmcore, cores))
+
+    print(cores)
+
+    if args.coverage:
+        cov = Path.cwd() / ".coverage"
+        if cov.is_file():
+            cov.unlink()
+
+    fail = False
+    results = defaultdict(list)
+    for core in cores:
+        if args.dwarf:
+            res = vmcore_test(core, coverage=args.coverage)
+            results[res].append(f"{core} (DWARF)")
+            if "fail" in res or "error" in res:
+                fail = True
+
+        if args.ctf:
+            res = vmcore_test(core, ctf=True, coverage=args.coverage)
+            results[res].append(f"{core} (CTF)")
+            if "fail" in res or "error" in res:
+                fail = True
+
+    if args.live:
+        res = live_test(coverage=args.coverage)
+        results[res].append("live (DWARF)")
+        if "fail" in res or "error" in res:
+            fail = True
+
+        res = live_test(ctf=True, coverage=args.coverage)
+        results[res].append("live (CTF)")
+        if "fail" in res or "error" in res:
+            fail = True
+
+    for status, vmcores in results.items():
+        print(f"==> {status}")
+        for vmcore in vmcores:
+            print(f"    {vmcore}")
+
+    if fail:
+        print("FAILED")
+        sys.exit(1)
+    else:
+        print("PASSED! Congratulations :)")
+
+
+if __name__ == "__main__":
+    main()

--- a/testing/vmcore.py
+++ b/testing/vmcore.py
@@ -210,7 +210,11 @@ def upload_all(client: ObjectStorageClient, core: str) -> None:
     vmcore_path = core_path / "vmcore"
     if not vmlinux_path.exists() or not vmcore_path.exists():
         sys.exit("error: missing vmcore or vmlinux file")
-    uploads = [vmlinux_path, vmcore_path] + list(core_path.glob("*.ko.debug"))
+    uname = core_path / "UTS_RELEASE"
+    if not uname.exists():
+        sys.exit("error: missing UTS_RELEASE file")
+    uploads = [vmlinux_path, vmcore_path, uname]
+    uploads += list(core_path.glob("*.ko.debug"))
     uploads += list(core_path.glob("vmlinux.ctfa*"))
     object_to_size = {obj.name: obj.size for obj in all_objects(client)}
     with progress, ThreadPoolExecutor(max_workers=4) as pool:

--- a/testing/vmcore.py
+++ b/testing/vmcore.py
@@ -211,6 +211,7 @@ def upload_all(client: ObjectStorageClient, core: str) -> None:
     if not vmlinux_path.exists() or not vmcore_path.exists():
         sys.exit("error: missing vmcore or vmlinux file")
     uploads = [vmlinux_path, vmcore_path] + list(core_path.glob("*.ko.debug"))
+    uploads += list(core_path.glob("vmlinux.ctfa*"))
     object_to_size = {obj.name: obj.size for obj in all_objects(client)}
     with progress, ThreadPoolExecutor(max_workers=4) as pool:
         futures = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+import os
 import sys
 from fnmatch import fnmatch
 from pathlib import Path
@@ -24,8 +25,12 @@ def prog() -> drgn.Program:
     p = drgn.Program()
     if VMCORE:
         p.set_core_dump(VMCORE)
-    else:
+    elif os.geteuid() == 0:
         p.set_kernel()
+    else:
+        from drgn.internal.sudohelper import open_via_sudo
+
+        p.set_core_dump(open_via_sudo("/proc/kcore", os.O_RDONLY))
     if CTF:
         try:
             from drgn.helpers.linux.ctf import load_ctf

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 import os
+import shutil
 import subprocess
 import time
 from pathlib import Path
@@ -13,6 +14,8 @@ from drgn_tools import block
 
 @pytest.fixture(scope="module")
 def fio(prog_type):
+    if not shutil.which("fio"):
+        pytest.skip("fio is not available")
     if "DRGNTOOLS_BLOCK_TEST_DIR" in os.environ:
         path = Path(os.environ["DRGNTOOLS_BLOCK_TEST_DIR"])
     else:


### PR DESCRIPTION
The existing test frameworks don't give us a good opportunity to run tests against the version of drgn which was installed via RPM. Instead, they run tests against a version downloaded from PyPI.

This makes it difficult to run tests that use CTF, and especially difficult to run tests that are using the system CTF implementation from the drgn / binutils RPMs.

So, I'm adding a test runner that is designed to run directly on a OL system after installing the drgn RPM. Essentially, it should look like this:

```bash
sudo yum install -y path_to_drgn_with_ctf.rpm
python3 -m pip install --user 'pytest<7.1'
# optionally, get the kernel-uek-debuginfo RPM for the running kernel
python3 -m testing.rpm --core-dir path/to/vmcores
```

The test runner doesn't use Tox, like the rest of our runners. This is probably for the best, and I think I will be getting rid of tox going forward, but that's a problem for me to think about a bit later.

The test runner will run tests against every vmcore in the `--core-dir`. It will also run tests against the running kernel. It will attempt to run tests once using DWARF, and once using CTF. However, we need to be careful about CTF compatibility issues. There are several constraints at play:

* The necessary commits to read kallsyms out of a vmcore file were backported to UEK. So we need to be able to detect these.
* There was a data issue with OL8, UEK6 CTF that was fixed.
* On OL7, the binutils/libctf is not forward-compatible with CTF from OL8 and OL9.

So as part of this, I've added UEK version detection and a CTF compatibility checker. Soon this will be used by Corelens and CLI so that we can avoid trying to load CTF if it is unsupported.

Another part of this is updating the vmcore upload/download system, so that it will also include `UTS_RELEASE` version info, as well as `vmlinux.ctfa` CTF archives for CTF testing. I've already done so for all vmcores.

I've added a few fixes for items that came up during testing - a new vmcore was added which uncovered:
1. An issue with bt.
2. A recent change to md in UEK7 which broke the md helpers.

---

With all of this, the latest CTF-enabled RPM has the following results:

- OL7: passes on vmcores with DWARF and CTF. (except for the segfault in libkdumpfile, and the vmcores for which OL7's libctf is not compatible)
- OL8: passes on vmcores with DWARF and CTF. (except for the segfault in libkdumpfile)
- OL9: passes on vmcores with DWARF and CTF. (except for the segfault in libkdumpfile)