### PR TITLE
Documentation updates, type annotation fixes, and new Table helpers

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@ vmtest:
     - mkdir -p tmp/overlays tmp/info
     - tox -e runner -- python -m testing.heavyvm.runner --image-dir /var/drgn-tools/images --vm-info-dir tmp/info --overlay-dir tmp/overlays --tarball archive.tar.gz
   artifacts:
+    when: always
     paths:
       - vmcore.xml
     reports:

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -89,6 +89,14 @@ drgn\_tools.dentry module
    :undoc-members:
    :show-inheritance:
 
+drgn\_tools.dm module
+---------------------
+
+.. automodule:: drgn_tools.dm
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 drgn\_tools.ext4\_dirlock module
 --------------------------------
 
@@ -141,6 +149,14 @@ drgn\_tools.logging module
 --------------------------
 
 .. automodule:: drgn_tools.logging
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+drgn\_tools.lsmod module
+------------------------
+
+.. automodule:: drgn_tools.lsmod
    :members:
    :undoc-members:
    :show-inheritance:
@@ -209,6 +225,14 @@ drgn\_tools.nvme module
    :undoc-members:
    :show-inheritance:
 
+drgn\_tools.partition module
+----------------------------
+
+.. automodule:: drgn_tools.partition
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 drgn\_tools.printk module
 -------------------------
 
@@ -221,6 +245,30 @@ drgn\_tools.rds module
 ----------------------
 
 .. automodule:: drgn_tools.rds
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+drgn\_tools.runq module
+-----------------------
+
+.. automodule:: drgn_tools.runq
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+drgn\_tools.scsi module
+-----------------------
+
+.. automodule:: drgn_tools.scsi
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+drgn\_tools.slabinfo module
+---------------------------
+
+.. automodule:: drgn_tools.slabinfo
    :members:
    :undoc-members:
    :show-inheritance:

--- a/drgn_tools/dentry.py
+++ b/drgn_tools/dentry.py
@@ -17,7 +17,7 @@ from drgn.helpers.linux.list import list_for_each_entry
 from drgn_tools.corelens import CorelensModule
 from drgn_tools.itertools import count
 from drgn_tools.itertools import take
-from drgn_tools.table import print_row
+from drgn_tools.table import FixedTable
 from drgn_tools.util import kernel_version
 
 
@@ -222,37 +222,41 @@ def print_dentry_table(
 
     :param dentries: Any iterable of ``struct dentry *``
     """
+
     if refcount:
-        col_widths = [16] * 3 + [5, 4, 0]
-        print_row(
-            ["DENTRY", "SUPER_BLOCK", "INODE", "REFCOUNT", "TYPE", "PATH"],
-            col_widths,
+        table = FixedTable(
+            [
+                "DENTRY:016x",
+                "SUPER_BLOCK:016x",
+                "INODE:016x",
+                "CNT:>",
+                "TYPE",
+                "PATH",
+            ]
         )
     else:
-        col_widths = [16] * 3 + [4, 0]
-        print_row(
-            ["DENTRY", "SUPER_BLOCK", "INODE", "TYPE", "PATH"], col_widths
+        table = FixedTable(
+            ["DENTRY:016x", "SUPER_BLOCK:016x", "INODE:016x", "TYPE", "PATH"]
         )
     for d in dentries:
         file_type = __file_type(int(d.d_inode.i_mode)) if d.d_inode else "NONE"
         if refcount:
-            row = [
-                f"{d.value_():016x}",
-                f"{d.d_sb.value_():016x}",
-                f"{d.d_inode.value_():016x}",
-                str(int(d_count(d))),
+            table.row(
+                d.value_(),
+                d.d_sb.value_(),
+                d.d_inode.value_(),
+                int(d_count(d)),
                 file_type,
                 dentry_path_any_mount(d).decode(),
-            ]
+            )
         else:
-            row = [
-                f"{d.value_():016x}",
-                f"{d.d_sb.value_():016x}",
-                f"{d.d_inode.value_():016x}",
+            table.row(
+                d.value_(),
+                d.d_sb.value_(),
+                d.d_inode.value_(),
                 file_type,
                 dentry_path_any_mount(d).decode(),
-            ]
-        print_row(row, col_widths)
+            )
 
 
 def dentry_is_used(dentry: Object) -> bool:

--- a/drgn_tools/lsmod.py
+++ b/drgn_tools/lsmod.py
@@ -18,7 +18,7 @@ def for_each_module_use(source_list_addr: Object) -> Iterable[Object]:
     """
     Provide the list of ``struct module_use`` as an iterable object
 
-    :param source_list_addr: ``struct module_use.source_list `` Object.
+    :param source_list_addr: ``struct module_use.source_list`` Object.
     :returns: A list of ``struct module.source_list`` as an iterable object
     """
     return list_for_each_entry(

--- a/drgn_tools/module.py
+++ b/drgn_tools/module.py
@@ -34,20 +34,22 @@ from drgn_tools.taint import Taint
 
 
 __all__ = (
-    "ensure_debuginfo",
-    "load_module_debuginfo",
+    "KernelModule",
     "ModuleLayout",
+    "ParamInfo",
+    "address_to_module",
+    "ensure_debuginfo",
+    "find_module",
+    "for_each_module",
+    "load_module_debuginfo",
     "module_address_region",
+    "module_build_id",
+    "module_exports",
     "module_init_region",
+    "module_params",
     "module_percpu_region",
     "module_symbols",
-    "module_exports",
     "module_unified_symbols",
-    "for_each_module",
-    "find_module",
-    "address_to_module",
-    "KernelModule",
-    "module_build_id",
 )
 
 
@@ -282,9 +284,13 @@ class ParamInfo(NamedTuple):
     """Contains information about a kernel module parameter"""
 
     name: str
+    """Name of the parameter"""
     kernel_param: Object
+    """The ``struct kernel_param *`` of this parameter"""
     type_name: str
+    """Type name (e.g. byte, short, uint)"""
     value: Optional[Object]
+    """If possible, the parameter's decoded value"""
 
 
 _MOD_PARAM_TYPES = {

--- a/drgn_tools/partition.py
+++ b/drgn_tools/partition.py
@@ -4,6 +4,7 @@
 Helper to print partition information
 """
 import argparse
+from typing import NamedTuple
 
 from drgn import Object
 from drgn import Program
@@ -14,71 +15,94 @@ from drgn.helpers.linux.device import MAJOR
 from drgn.helpers.linux.device import MINOR
 
 from drgn_tools.corelens import CorelensModule
-from drgn_tools.table import print_table
+from drgn_tools.table import Table
 
 
-def get_partinfo_from_blkdev_struct(part: Object) -> list:
+class PartInfo(NamedTuple):
     """
-    Collect partition information from `struct block_device`
+    Partition info, from either ``struct block_device`` or ``struct hd_struct``
+    """
+
+    major: int
+    minor: int
+    name: str
+    start_sect: int
+    nr_sects: int
+    ro: bool
+    obj: Object
+
+
+def get_partinfo_from_blkdev_struct(part: Object) -> PartInfo:
+    """
+    Collect partition information from ``struct block_device``
     Returns a list with partition information for the given partition.
     """
     devt = part.bd_dev.value_()
     name = part_name(part).decode()
     start_sect = int(part.bd_start_sect)
     nr_sects = int(part.bd_inode.i_size.value_() / 512)
-    ro = "Yes" if part.bd_read_only else "No"
-    return [
+    return PartInfo(
         MAJOR(devt),
         MINOR(devt),
         name,
         start_sect,
         nr_sects,
-        ro,
-        hex(part.value_()),
-    ]
+        bool(part.bd_read_only),
+        part,
+    )
 
 
-def get_partinfo_from_hd_struct(part: Object) -> list:
+def get_partinfo_from_hd_struct(part: Object) -> PartInfo:
     """
-    Collects partition information from `struct hd_struct`
+    Collects partition information from ``struct hd_struct``
     Returns a list with partition information for the given partition.
     """
     devt = part_devt(part)
     name = part_name(part).decode()
     start_sect = int(part.start_sect)
     nr_sects = part.nr_sects.value_()
-    ro = "Yes" if int(part.policy) else "No"
-    return [
+    return PartInfo(
         MAJOR(devt),
         MINOR(devt),
         name,
         start_sect,
         nr_sects,
-        ro,
-        hex(part.value_()),
-    ]
+        bool(part.policy),
+        part,
+    )
 
 
 def print_partition_info(prog: Program) -> None:
     """
     Prints partition information
     """
-    output = [["MAJOR", "MINOR", "NAME", "START", "SECTORS", "READ-ONLY"]]
+    table = Table(
+        [
+            "MAJOR",
+            "MINOR",
+            "NAME",
+            "START:>",
+            "SECTORS:>",
+            "READ-ONLY",
+            "OBJECT:016x",  # will be replaced, see below
+        ]
+    )
     part_is_blkdev = -1
     for part in for_each_partition(prog):
         if part_is_blkdev == -1:
             if "block_device" in part.type_.type_name():
                 part_is_blkdev = 1
-                output[0].append("BLOCK DEVICE")
+                table.header[-1] = "BLOCK DEVICE"
             else:
                 part_is_blkdev = 0
-                output[0].append("HD STRUCT")
+                table.header[-1] = "HD STRUCT"
         if part_is_blkdev == 1:
-            output.append(get_partinfo_from_blkdev_struct(part))
+            info = get_partinfo_from_blkdev_struct(part)
         else:
-            output.append(get_partinfo_from_hd_struct(part))
+            info = get_partinfo_from_hd_struct(part)
+        table.row(*info._replace(obj=info.obj.value_()))
 
-    print_table(output)
+    table.write()
 
 
 class PartitionInfo(CorelensModule):

--- a/drgn_tools/slabinfo.py
+++ b/drgn_tools/slabinfo.py
@@ -20,7 +20,7 @@ from drgn.helpers.linux.slab import _get_slab_cache_helper
 from drgn.helpers.linux.slab import for_each_slab_cache
 
 from drgn_tools.corelens import CorelensModule
-from drgn_tools.table import print_table
+from drgn_tools.table import FixedTable
 
 
 class SlabCacheInfo(NamedTuple):
@@ -252,23 +252,29 @@ def get_kmem_cache_slub_info(cache: Object) -> SlabCacheInfo:
 
 def print_slab_info(prog: Program) -> None:
     """Helper to print slab information"""
-    output = [
-        ["CACHE", "OBJSIZE", "ALLOCATED", "TOTAL", "SLABS", "SSIZE", "NAME"]
-    ]
+    table = FixedTable(
+        [
+            "CACHE:016x",
+            "OBJSIZE:>",
+            "ALLOCATED:>",
+            "TOTAL:>",
+            "SLABS:>",
+            "SSIZE:>",
+            "NAME",
+        ]
+    )
     for cache in for_each_slab_cache(prog):
         slabinfo = get_kmem_cache_slub_info(cache)
-        output.append(
-            [
-                hex(slabinfo.cache.value_()),
-                str(slabinfo.objsize),
-                str(slabinfo.allocated),
-                str(slabinfo.total),
-                str(slabinfo.nr_slabs),
-                f"{int(slabinfo.ssize / 1024)}k",
-                slabinfo.name,
-            ]
+        table.row(
+            slabinfo.cache.value_(),
+            slabinfo.objsize,
+            slabinfo.allocated,
+            slabinfo.total,
+            slabinfo.nr_slabs,
+            f"{int(slabinfo.ssize / 1024)}k",
+            slabinfo.name,
         )
-    print_table(output)
+    table.write()
 
 
 class SlabInfo(CorelensModule):

--- a/drgn_tools/table.py
+++ b/drgn_tools/table.py
@@ -3,29 +3,9 @@
 import sys
 from typing import Any
 from typing import Dict
+from typing import Iterable
 from typing import List
 from typing import Optional
-
-
-def print_row(fields: List[Any], col_widths: List[int]):
-    """
-    Print a single row of a table, given pre-determined column widths
-
-    Note that this doesn't guarantee that the width of every field in the row
-    will be less than the width of the column: in that case, the field's full
-    contents will be printed and columns will be misaligned. For guaranteed
-    aligned columns, see print_table(), or be very careful about your column
-    widths.
-
-    :param fields: a list of fields to print
-    :param col_widths: the width of each field (not including spaces)
-    """
-    print(
-        "  ".join(
-            str(val) if w <= 0 else str(val).ljust(w)
-            for val, w in zip(fields, col_widths)
-        )
-    )
 
 
 def print_table(
@@ -64,6 +44,174 @@ def print_table(
 
     if outfile:
         out.close()
+
+
+class Table:
+    """
+    Create an aligned, formatted table
+
+    This helper makes it simple to create a text table which is aligned to your
+    requirements, and whose values are formatted with whatever string formatter
+    you'd like. The table will be written to stdout by default, but can be
+    written to a custom output file if you prefer.
+
+    To create the table, you need to specify all the columns. Each column is
+    specified by a string which contains the column name, and optionally a colon
+    (":") followed by a format string. You can prefix the format string with a
+    "<" or ">" to control the justification of the column (it is stripped from
+    the format string). By default, columns are left justified and formatted
+    using ``format(value, '')`` which is typically the same as ``str()``. Here
+    are some example column specifiers:
+
+    1. "TIME:>.3f" - a column named "TIME", right justified
+    2. "NAME" - a column named "NAME", left justified, formatted by str()
+    3. "PTR:016x" - a 16-digit hexadecimal value, 0-filled
+
+    Please note that this function will store all rows until ``write()`` is
+    called. This way, it can determine the expected column widths for all rows,
+    and align them accordingly. If you'd like your table rows to be printed as
+    they are created (e.g. if producing the output takes a long time, and you'd
+    like the user to see output as it becomes available), then you could use
+    :class:`FixedTable`.
+
+    :param header: a list of column specifiers, see above for details
+    :param outfile: optional output file name (default is stdout)
+    :param report: when true, outfile is opened in append mode
+    """
+
+    def __init__(
+        self,
+        header: List[str],
+        outfile: Optional[str] = None,
+        report: bool = False,
+    ):
+        # Name of each header
+        self.header = []
+        # Function (str, int) -> str to justify each column entry
+        self.justifier = []
+        # Format string for column
+        self.formats = []
+        for h in header:
+            just = str.ljust
+            if ":" in h:
+                name, fmt = h.rsplit(":", 1)
+            else:
+                name, fmt = h, ""
+            if len(fmt) > 0 and fmt[0] in ("<", ">"):
+                if fmt[0] == ">":
+                    just = str.rjust
+                fmt = fmt[1:]
+            self.header.append(name)
+            self.justifier.append(just)
+            self.formats.append(fmt)
+        self.widths = [len(h) for h in header]
+        self.rows: List[List[str]] = []
+        self.out = sys.stdout
+        self.close_output = bool(outfile)
+        if outfile and report:
+            self.out = open(outfile, "a")
+            self.out.write("\n\n")
+        elif outfile:
+            self.out = open(outfile, "w")
+
+    def _build_row(
+        self, fields: Iterable[Any], update_widths: bool = True
+    ) -> List[str]:
+        row = []
+        for i, data in enumerate(fields):
+            if i < len(self.header):
+                string = format(data, self.formats[i])
+            else:
+                string = str(data)
+            row.append(string)
+            if update_widths and len(string) > self.widths[i]:
+                self.widths[i] = len(string)
+            self.widths[i] = max(self.widths[i], len(string))
+        return row
+
+    def add_row(self, fields: Iterable[Any]) -> None:
+        """Add a row to the table (values expressed as a list)"""
+        self.rows.append(self._build_row(fields))
+
+    def row(self, *fields: Any) -> None:
+        """Add a row to the table (values expressed as positional args)"""
+        self.add_row(fields)
+
+    def _row_str(self, row: List[str]) -> str:
+        return "  ".join(
+            j(s, w) for j, s, w in zip(self.justifier, row, self.widths)
+        ).rstrip()
+
+    def write(self) -> None:
+        """Print the table to the output file"""
+        print(self._row_str(self.header), file=self.out)
+        for row in self.rows:
+            print(self._row_str(row), file=self.out)
+
+
+class FixedTable(Table):
+    """
+    Created an aligned, formatted table with fixed column widths
+
+    This is a variant of the :class:`Table` class, and it is designed to be
+    nearly a drop-in replacement. Unlike :class:`Table`, the column widths are
+    fixed  Unlike :class:`Table`, the column widths are "fixed"; that is they
+    are set up during initialization. This means that each row can be printed
+    immediately, which is great for letting users know that progress is being
+    made. The trade-off is that if any row contains a column value which is too
+    wide, the row will become unaligned. This is makes output less visually
+    appealing, but frequently it can be avoided by designing the table
+    carefully.
+
+    The column widths can be specified in one of two ways. First, you may
+    specify a list of widths to this constructor. In that case, the table header
+    is immediately printed, and the given widths are used exactly as provided.
+    Alternatively, you can omit the ``widths`` argument. When the first row is
+    printed, column widths are calculated using the width of each value in the
+    row (and also the header width) to ensure everything fits. This is an
+    especially useful behavior if your table data is already fixed-width anyway:
+    you don't need to hand-calculate widths and risk them going out of date.
+
+    The other behaviors of this class are identical to :class:`Table`.  Please
+    note that even though this table tends to print rows immediately, it is
+    still good practice to use call ``write()`` once finished adding rows. This
+    makes it trivial to swap out the implementation for :class:`Table` if
+    desired.
+
+    :param header: column specifiers for the table
+    :param widths: optional list of column widths
+    :param kwargs: remainder of arguments are passed to :class:`Table`
+    """
+
+    def __init__(
+        self, header: List[str], widths: Optional[List[int]] = None, **kwargs
+    ):
+        super().__init__(header, **kwargs)
+        self.print_immediately = False
+        if widths:
+            self.widths = widths
+            self.print_immediately = True
+            print(self._row_str(self.header), file=self.out)
+
+    def add_row(self, fields: Iterable[Any]) -> None:
+        """Add a row to the table (it is immediately printed)"""
+        # Use the first row to determine widths if they weren't provided at the
+        # constructor. Once that is done, print the header, and from then on, we
+        # won't update the field widths as we go.
+        if not self.print_immediately:
+            self.print_immediately = True
+            row = self._build_row(fields, update_widths=True)
+            print(self._row_str(self.header), file=self.out)
+        else:
+            row = self._build_row(fields, update_widths=False)
+        print(self._row_str(row), file=self.out)
+
+    def write(self) -> None:
+        """Signals that no more rows will be added."""
+        if not self.print_immediately:
+            # The header was never printed. Do it now, since we are expected to
+            # print a blank table.
+            print(self._row_str(self.header), file=self.out)
 
 
 def print_dictionary(

--- a/drgn_tools/table.py
+++ b/drgn_tools/table.py
@@ -155,13 +155,12 @@ class FixedTable(Table):
 
     This is a variant of the :class:`Table` class, and it is designed to be
     nearly a drop-in replacement. Unlike :class:`Table`, the column widths are
-    fixed  Unlike :class:`Table`, the column widths are "fixed"; that is they
-    are set up during initialization. This means that each row can be printed
-    immediately, which is great for letting users know that progress is being
-    made. The trade-off is that if any row contains a column value which is too
-    wide, the row will become unaligned. This is makes output less visually
-    appealing, but frequently it can be avoided by designing the table
-    carefully.
+    "fixed"; that is they are set up during initialization. This means that each
+    row can be printed immediately, which is great for letting users know that
+    progress is being made. The trade-off is that if any row contains a column
+    value which is too wide, the row will become unaligned. This is makes output
+    less visually appealing, but frequently it can be avoided by designing the
+    table carefully.
 
     The column widths can be specified in one of two ways. First, you may
     specify a list of widths to this constructor. In that case, the table header


### PR DESCRIPTION
The partition info and slabinfo helpers had a couple small items that I wanted to address related to the docstrings and type annotations. I tweaked them and ensured that documentation builds successfully.

I also added two new table helpers: `Table` and `FixedTable`. Their docstrings should be self-explanatory, but the nice thing about them is that they can take care of the string formatting on your behalf, and they can also align individual columns to the left and right. By using `FixedTable`, you can also get output that is printed immediately, rather than all at once at the end of a loop. This is a major improvement for users, as it stinks to run a command and wait for a long time for a table to be output. To show the improvement, I moved the dentrycache helper to it, and the slabinfo helper, which can run a bit slow on heavily fragmented machines.