### PR TITLE
Fix bt and release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ Unreleased
 
 Changes which are committed to git, but not yet released, may appear here.
 
+0.8.0 - Wed, Jan 31, 2023
+-------------------------
+
+Another intermediate release prior to 1.0.0. We have a few new corelens modules,
+and some fixes and general improvements.
+
+### Added
+
+- `slabinfo` corelens module
+- `partitioninfo` corelens module
+- `CtfCompatibility` to automatically detect which UEK kernels are compatible
+  with CTF debuginfo
+
+### Fixed
+
+- `bt` corelens module is more resilient to unwind errors
+- `md` helpers now support kernels containing a92ce0feffee ("md: drop queue
+  limitation for RAID1 and RAID10"), from 5.17
+
+### Changed
+
+- `bt()` function now outputs the task state in `[]` brackets as part of the
+  header
+- `scsiinfo` now outputs more useful fields
+- Several minor improvements to testing infrastructure
+
 0.7.0 - Tue, Jan 9, 2023
 ------------------------
 

--- a/drgn_tools/bt.py
+++ b/drgn_tools/bt.py
@@ -411,14 +411,19 @@ def bt(
       other functions in this module, which do not print the frames.
     """
     task = _bt_user_friendly_arg(task_or_prog, cpu=cpu, pid=pid)
-    traces = expand_traces(task.prog_.stack_trace(task))
     # We call this "task", but it's legal to provide a struct pt_regs. This
     # function should work fine, but not print the header, in that case.
     if task.type_.type_name() in (
         "struct task_struct",
         "struct task_struct *",
     ):
+        state = task_state_to_char(task)
         print_task_header(task)
+        if state in ("Z", "X"):
+            print(f"Task is in state: {state} - cannot unwind")
+            return []
+
+    traces = expand_traces(task.prog_.stack_trace(task))
     print_traces(traces, show_vars=show_vars, show_absent=show_absent)
     frames = None
     if retframes:

--- a/drgn_tools/nvme.py
+++ b/drgn_tools/nvme.py
@@ -296,12 +296,14 @@ class NvmeModule(CorelensModule):
     debuginfo_kmods = ["nvme", "nvme_core"]
 
     default_args = [
-        "--firmware",
-        "--ctrl",
-        "--queue",
-        "--namespace",
-        "--queuemap",
-        "--msimask",
+        [
+            "--firmware",
+            "--ctrl",
+            "--queue",
+            "--namespace",
+            "--queuemap",
+            "--msimask",
+        ]
     ]
 
     def add_args(self, parser: argparse.ArgumentParser) -> None:

--- a/drgn_tools/task.py
+++ b/drgn_tools/task.py
@@ -351,7 +351,7 @@ class Taskinfo(CorelensModule):
 
     name = "ps"
 
-    default_args = ["-m"]
+    default_args = [["-m"]]
 
     def add_args(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(

--- a/drgn_tools/virtio.py
+++ b/drgn_tools/virtio.py
@@ -936,7 +936,7 @@ class Virtio(CorelensModule):
 
     name = "virtio"
     debuginfo_kmods = ["*virtio*"]
-    default_args = ["--show-vq"]
+    default_args = [["--show-vq"]]
 
     def add_args(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 long_description = "drgn helper script repository"
 
-RELEASE_VERSION = "0.7.0"
+RELEASE_VERSION = "0.8.0"
 
 
 def get_version():


### PR DESCRIPTION
Updates `bt` to skip zombie tasks, and adds some filtering logic for the `bt` corelens module which I think will be quite useful.

Relase 0.8.0 after that, for packaging up to our various environments.