### PR TITLE
lock: sem: add other __down variants in scan.

### DIFF
--- a/drgn_tools/lock.py
+++ b/drgn_tools/lock.py
@@ -127,6 +127,18 @@ def scan_sem_lock(prog: Program, stack: bool) -> None:
     if frame_list:
         show_sem_lock(prog, frame_list, seen_sems, stack)
 
+    frame_list = bt_has(prog, "__down_interruptible")
+    if frame_list:
+        show_sem_lock(prog, frame_list, seen_sems, stack)
+
+    frame_list = bt_has(prog, "__down_killable")
+    if frame_list:
+        show_sem_lock(prog, frame_list, seen_sems, stack)
+
+    frame_list = bt_has(prog, "__down_timeout")
+    if frame_list:
+        show_sem_lock(prog, frame_list, seen_sems, stack)
+
 
 def scan_lock(prog: Program, stack: bool) -> None:
     """Scan tasks for Mutex and Semaphore"""


### PR DESCRIPTION
I am seeing call stacks like ones shown below are getting missed by scan_sem_lock.

PID: 1174   TASK: ffff953cfc723100  CPU: 2   COMMAND: sem_waiter
 #0 [ffffb902c05cbda0] __schedule at ffffffff86f7a86b
 #1 [ffffb902c05cbe28] schedule at ffffffff86f7ad9d
 #2 [ffffb902c05cbe38] schedule_timeout at ffffffff86f7d94d
 #3 [ffffb902c05cbe98] __down_killable at ffffffff86f7ccb6
 #4 [ffffb902c05cbee0] down_killable at ffffffff8668d69d

PID: 1181   TASK: ffff99c2bc6a6e40  CPU: 1   COMMAND: sem_waiter
 #0 [ffffa3780060bda0] __schedule at ffffffffbb77a86b
 #1 [ffffa3780060be28] schedule at ffffffffbb77ad9d
 #2 [ffffa3780060be38] schedule_timeout at ffffffffbb77d8df
 #3 [ffffa3780060be98] __down_timeout at ffffffffbb77cdc4
 #4 [ffffa3780060bee0] down_timeout at ffffffffbae8d740

PID: 1175   TASK: ffff96c3fc5a55c0  CPU: 1   COMMAND: sem_waiter
 #0 [ffff9f35c0543da0] __schedule at ffffffff82b7a86b
 #1 [ffff9f35c0543e28] schedule at ffffffff82b7ad9d
 #2 [ffff9f35c0543e38] schedule_timeout at ffffffff82b7d94d
 #3 [ffff9f35c0543e98] __down_interruptible at ffffffff82b7cef6
 #4 [ffff9f35c0543ee0] down_interruptible at ffffffff8228d7dd

down_interruptible and down_timeout are fairly common interfaces, especially in device drivers.

down_killable is not that common, so can be removed if don't deem it important enough for an extra scan.