### PR TITLE
Fixes for recently merged helpers

### DIFF
--- a/drgn_tools/crash_net.py
+++ b/drgn_tools/crash_net.py
@@ -146,17 +146,18 @@ def print_net_devices(prog: Program) -> None:
     :returns: None.
     """
     rows = [["NET_DEVICE", "NAME", "IP ADDRESS(ES)"]]
-
     net_namespaces = network.for_each_net(prog)
+
     for net_namespace in net_namespaces:
         for name, dev in for_each_netdev(net_namespace):
             net_device_ptr = hex(dev.dev.platform_data)
+            net_device_name = dev.dev.kobj.name.string_().decode()
             ip_list = [str(a) for a in netdev_ipv4s(dev) + netdev_ipv6s(dev)]
             ips = ", ".join(ip_list)
             rows.append(
                 [
                     net_device_ptr,
-                    name,
+                    net_device_name,
                     ips,
                 ]
             )
@@ -218,7 +219,9 @@ def print_arp_cache(prog: Program) -> None:
         ip_bytes = prog.read(neigh.primary_key.address_of_(), 4)
         ip_addr = str(ipaddress.IPv4Address(ip_bytes))
 
-        mac_bytes = prog.read(neigh.ha.address_of_(), 6)
+        addr_len = neigh.dev.addr_len
+
+        mac_bytes = prog.read(neigh.ha.address_of_(), addr_len)
         hw_addr = ":".join(f"{b:02x}" for b in mac_bytes)
         dev_name = neigh.dev.name.string_().decode()
 
@@ -348,7 +351,7 @@ def print_task_sockets(prog: Program, pid: int, print_full_data: bool) -> None:
         cnt = cnt + 1
         rows.append(
             [
-                str(cnt),
+                fd,
                 hex(socket.value_())[2:],
                 hex(socket.sk.value_())[2:],
                 sock_family + ":" + sock_type,

--- a/drgn_tools/meminfo.py
+++ b/drgn_tools/meminfo.py
@@ -14,6 +14,7 @@ import drgn
 from drgn import Object
 from drgn import Program
 from drgn.helpers.linux import list_for_each_entry
+from drgn.helpers.linux.boot import pgtable_l5_enabled
 from drgn.helpers.linux.percpu import percpu_counter_sum
 
 from drgn_tools.corelens import CorelensModule
@@ -120,7 +121,7 @@ def get_mm_constants(prog: Program) -> Dict[str, int]:
             # arch/x86/include/asm/pgtable_64_types.h
             _pmd_shift = 21
             if "vmalloc_base" in prog:
-                _vmalloc_size_tb = 32
+                _vmalloc_size_tb = 12800 if pgtable_l5_enabled(prog) else 32
                 mm_consts["VMALLOC_START"] = prog["vmalloc_base"].value_()
                 mm_consts["VMALLOC_END"] = (
                     mm_consts["VMALLOC_START"] + (_vmalloc_size_tb << 40) - 1


### PR DESCRIPTION
The virtutil module contained some test failures:

- UEK4 does not contain the `cpuhp_state` variable, handle it gracefully
- UEK6 CTF seems to omit the type for one variable, causing a KeyError. This is definitely a CTF bug (and from my initial investigation, appears to be a bug in CTF _generation_ not the drgn CTF code). Work around it here to ensure tests pass.

The net module was missing some changes that had been applied as part of the code review, introduce them here.