### PR TITLE
Github actions fix, UEK-next support, and a table fix

### DIFF
--- a/.github/workflows/litevm.yml
+++ b/.github/workflows/litevm.yml
@@ -63,32 +63,6 @@ jobs:
           tox list
           tox --notest
           tox -e runner --notest
-
-      # Use Github Actions to cache RPMs by date. This can save a couple minutes
-      # in the run, which is nice. The cache contains the Yum sqlite database,
-      # and the downloaded RPMs.
-      #
-      # A cache miss results in getting the most recent cached data (e.g. from
-      # yesterday). The runner will check the repo metadata and get the updated
-      # data, and delete any stale data, so after the run completes, the
-      # testdata can be cached for future runs.
-      #
-      # On a cache hit, the test runner will still check the yum repo metadata,
-      # and if it differs from the cached data, it will clear and download it.
-      # So a cache hit isn't guaranteed to speed things up, but kernel packages
-      # aren't usually updated _that_ frequently.
-      - name: Get Date
-        id: get-date
-        run: |
-          echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
-        shell: bash
-      - name: Cache RPMs
-        uses: actions/cache@v3
-        with:
-          path: testdata/yumcache
-          key: ${{ runner.os }}-rpms-${{ steps.get-date.outputs.date }}
-          restore-keys: |
-            ${{ runner.os }}-rpms-
       - name: Fetch RPMs
         run: |
           tox -e runner -- python -m testing.litevm.rpm

--- a/drgn_tools/corelens.py
+++ b/drgn_tools/corelens.py
@@ -549,6 +549,8 @@ def _run_module(
         if print_header:
             print(f"\n====== MODULE {mod.name} ======")
         mod.run(prog, args)
+    except (KeyboardInterrupt, BrokenPipeError):
+        raise
     except Exception:
         formatted = traceback.format_exc()
         errors.append(
@@ -791,4 +793,9 @@ if __name__ == "__main__":
     # terrible, terrible corner of Python.
     import drgn_tools.corelens
 
-    drgn_tools.corelens.main()
+    try:
+        drgn_tools.corelens.main()
+    except KeyboardInterrupt:
+        sys.exit("interrupted")
+    except BrokenPipeError:
+        pass

--- a/drgn_tools/table.py
+++ b/drgn_tools/table.py
@@ -38,7 +38,7 @@ def print_table(
             "".join(
                 str(val).ljust(col_width + 2)
                 for (val, col_width) in zip(entry, col_widths)
-            ).strip(),
+            ).rstrip(),
             file=out,
         )
 


### PR DESCRIPTION
There are three separate changes here, sorry. But each is small and easy to understand.

1. Add support for UEK-next, so corelens will run against it. Also add uek-next to the "lite VM" tests, but don't enable it yet because some tests fail. I've cataloged all the failures.
2. Get rid of caching in github actions, it doesn't save any time and it causes more failures.
3. Fix alignment of some tables.