### PR TITLE
LSE-368: tests: Fix test failures due to movement of cpu_number.

### DIFF
--- a/tests/test_mm.py
+++ b/tests/test_mm.py
@@ -63,7 +63,7 @@ def test_AddrKind_categorize_data(prog: drgn.Program) -> None:
     assert mm.AddrKind.categorize(prog, bss) == mm.AddrKind.BSS
 
     # percpu
-    pcpu = prog.symbol("cpu_number").address
+    pcpu = prog.symbol("runqueues").address
     assert mm.AddrKind.categorize(prog, pcpu) == mm.AddrKind.PERCPU
 
 


### PR DESCRIPTION
cpu_number has been merged into pcpu_hot object, for x86, in newer (v6.2+) kernels. For some archs like aarch64, it still exists as per-cpu variable.

Since we just need a per-cpu address for this test, use per-cpu runqueues. These have been existing as per-cpu varibale for long time and even if this changes in future the change will be architecture independent, so we would not have to worry about test passing for one arch and failing for other.

LSE-368.