### PR TITLE
Fix parsing of uek-next versions for 6.9.0

### DIFF
--- a/drgn_tools/debuginfo.py
+++ b/drgn_tools/debuginfo.py
@@ -509,7 +509,7 @@ class KernelVersion(NamedTuple):
         version_re = re.compile(
             r"(?P<version>\d+\.\d+\.\d+)-(?P<release>[0-9.-]+)"
             r"(?P<extraversion1>\.[0-9a-zA-Z._]+?)?"
-            r"\.el(?P<ol_version>\d+)(?P<extra>uek|_(?P<update>\d+)|)"
+            r"\.el(?P<ol_version>\d+)(?P<extra>uek|ueknext|_(?P<update>\d+)|)"
             r"(?P<extraversion2>\.[0-9a-zA-Z._]+?)?"
             r"\.(?P<arch>.+)"
         )
@@ -531,7 +531,12 @@ class KernelVersion(NamedTuple):
         uek_ver = None
         if is_uek:
             uek_ver = _UEK_VER.get(match["version"])
-        is_uek_next = is_uek and uek_ver is None and version_tuple >= (6, 8, 0)
+        is_uek_next = (
+            match["extra"] == "ueknext"
+            # In the initial 6.8.0 releases of UEK-next, there was no "ueknext"
+            # in the extra part of the version. Since 6.9.0 this is present.
+            or (is_uek and uek_ver is None and version_tuple == (6, 8, 0))
+        )
         return cls(
             match["version"],
             version_tuple,


### PR DESCRIPTION
This is a branch to handle the change in uek-next version strings:

from: 6.8.0-2.el9uek.x86_64
to: 6.9.0-2.el9ueknext.x86_64

I did go ahead and make fixes for uek-next tests to allow them to pass. However, I've removed those to a branch which will not be part of the v1 milestone as they're not super important.