### PR TITLE
testing: litevm: remove RPM & extracted files after each test

### DIFF
--- a/.github/workflows/litevm.yml
+++ b/.github/workflows/litevm.yml
@@ -63,10 +63,6 @@ jobs:
           tox list
           tox --notest
           tox -e runner --notest
-      - name: Fetch RPMs
-        run: |
-          tox -e runner -- python -m testing.litevm.rpm
-
       - name: Run tests
         run: |
-          tox -e runner -- python -m testing.litevm.vm --python-version 3${{ matrix.python-minor }}
+          tox -e runner -- python -m testing.litevm.vm --delete-after-test --python-version 3${{ matrix.python-minor }}

--- a/testing/litevm/rpm.py
+++ b/testing/litevm/rpm.py
@@ -233,6 +233,11 @@ class TestKernel:
             self._get_rpms()
         return self._rpm_paths + [self._dbinfo_path]
 
+    def delete_cache(self) -> None:
+        """Removes all RPMs and the RPM cache."""
+        tree = self.cache_dir / self.slug()
+        shutil.rmtree(tree)
+
     def get_oot_modules(self) -> List[Path]:
         key = f"ol{self.ol_ver}uek{self.uek_ver}{self.arch}"
         path = Path(__file__).parent / "mod" / key

--- a/testing/litevm/vm.py
+++ b/testing/litevm/vm.py
@@ -405,6 +405,11 @@ def main():
         help="Use CTF debuginfo for tests rather than DWARF",
     )
     parser.add_argument(
+        "--delete-after-test",
+        action="store_true",
+        help="Delete RPM cache and extract directory after test",
+    )
+    parser.add_argument(
         "command",
         nargs="*",
         help="Command to run on each vm (leave empty for default: test)",
@@ -423,7 +428,12 @@ def main():
         section_name = f"uek{k.uek_ver}"
         section_text = f"Run tests on UEK{k.uek_ver}"
         with ci_section(section_name, section_text):
+            release = k.latest_release()
+            extract_dir = args.extract_dir / release
             run_vm(k, args.extract_dir, commands)
+            if args.delete_after_test:
+                shutil.rmtree(extract_dir)
+                k.delete_cache()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This reduces the total disk space required during each test, and avoids errors resulting from filling up the disk.