### PR TITLE
A slabinfo fix, and the v1 (1.1.0) release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,64 @@
 Changelog
 =========
 
+Release Cycle
+-------------
+
+Prior to v1, the version numbers loosely followed the rule that new features
+would bump the minor version level, and bug fix releases would bump the patch
+version level.
+
+Beginning with v1, a new scheme is adopted which allows for a "development"
+version, and a stable version. Using the version numbers `x.y.z`, we have:
+
+1. The **development** version is of the form `x.0.z`, where `x` represents the
+   major version under development. Each release is performed by incrementing
+   `z`, the patch level, regardless of the type of changes. The development
+   version ends with the release of the "stable" version of `x.1.0`. The
+   development version is maintained on the `main` branch.
+2. The **stable** version is of the form `x.y.z`, where `y >= 1`, and `x` is of
+   course the major version. The "stable" versions are the only ones which are
+   released to Oracle Linux as RPMs. Releases will generally increment `z`, the
+   patch version, for bug fix releases. It's possible that in rare cases, we
+   will increment `y` for backports, in cases where we want to backport a module
+   to the stable release. The stable version is maintained in a branch named
+   `stable/vX`, where `X` is replaced with the major version number (e.g.
+   `stable/v1`).
+
+The stable version is maintained in parallel as the development version is
+developed. Fixes in the stable release must first be present in the development
+release (and all newer stable releases, if applicable).
+
+For the most part, regular maintenance of the stable version will end with the
+release of the next stable version, but maintenance may continue at our
+discretion.
+
+Examples:
+
+- `1.1.0` - the initial public release of the `1.x` stable series.
+- `1.1.1` - the first bugfix release of the `1.x` stable series.
+- `2.0.0` - the initial development version of the `2.x`.
+- `2.0.1` - an incremental development release in `2.x` development. It may
+  contain bug fixes or new features.
+- `2.1.0` - the initial public release of the `2.x` stable series.
+
+
 Unreleased
 ----------
 
 Changes which are committed to git, but not yet released, may appear here.
+
+1.1.0 - Tue, Aug 27, 2023
+-------------------------
+
+This is the first public release of drgn-tools!
+
+* Fixes for the irq, workqueue, bt, & nfs_tools modules.
+* Add ls and fsnotify modules.
+* Added new helpers for tasks & task states.
+* Basic functionality for running on UEK-NEXT (unsupported).
+* RPM name updated to "drgn-tools".
+* Support for CTF debuginfo added for the locks module.
 
 0.9.1 - Mon, Apr 22, 2023
 -------------------------

--- a/buildrpm/python-drgn-tools.spec
+++ b/buildrpm/python-drgn-tools.spec
@@ -1,7 +1,7 @@
 # Copyright (c) 2024, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 Name:           python-drgn-tools
-Version:        0.9.1
+Version:        1.1.0
 Release:        1%{?dist}
 Summary:        Helper scripts for drgn, containing the corelens utility
 
@@ -61,6 +61,9 @@ rm %{buildroot}/usr/bin/DRGN
 %{_mandir}/man1/corelens.1.gz
 
 %changelog
+* Tue Aug 27 2024 Stephen Brennan <stephen.s.brennan@oracle.com> - 1.1.0-1
+- Update to 1.1.0
+
 * Mon Apr 22 2024 Stephen Brennan <stephen.s.brennan@oracle.com> - 0.9.1-1
 - Update to 0.9.1
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 long_description = "drgn helper script repository"
 
-RELEASE_VERSION = "0.9.1"
+RELEASE_VERSION = "1.1.0"
 PACKAGES = ["drgn_tools"]
 if not os.environ.get("DRGN_TOOLS_V2_OMIT"):
     PACKAGES.append("drgn_tools.v2")


### PR DESCRIPTION
The slabinfo fix was more involved than I wanted, but it works well, is compatible with drgn 0.0.25 - 0.0.27, and it actually makes the `slabinfo` module modestly faster.