### PR TITLE
runq: add prio and runtime

### DIFF
--- a/drgn_tools/runq.py
+++ b/drgn_tools/runq.py
@@ -67,13 +67,12 @@ def _print_cfs_runq(runqueue: Object) -> None:
         print("     [no tasks queued]")
 
 
-def run_queue(prog: Program, min_run_time_seconds: int = 0) -> None:
+def run_queue(prog: Program) -> None:
     """
-    Print tasks which are in the RT and CFS runqueues on each CPU. Specify min_run_time_seconds to x to only print
+    Print tasks which are in the RT and CFS runqueues on each CPU.
     processes running more than x seconds.
 
     :param prog: drgn program
-    :param min_run_time_seconds: int
     """
 
     # _cpu = drgn.helpers.linux.cpumask.for_each_online_cpu(prog)
@@ -85,8 +84,6 @@ def run_queue(prog: Program, min_run_time_seconds: int = 0) -> None:
         pid = curr_task.pid.value_()
         run_time = task_lastrun2now(curr_task)
         prio = curr_task.prio.value_()
-        if run_time < min_run_time_seconds * 1e9:
-            continue
         print(f"CPU {cpus} RUNQUEUE: {runqueue.address_of_().value_():x}")
         print(
             f"  CURRENT:   PID: {pid:<6d}  TASK: {curr_task_addr:x}  PRIO: {prio}"

--- a/drgn_tools/runq.py
+++ b/drgn_tools/runq.py
@@ -11,6 +11,8 @@ from drgn.helpers.linux.list import list_for_each_entry
 from drgn.helpers.linux.percpu import per_cpu
 
 from drgn_tools.corelens import CorelensModule
+from drgn_tools.task import task_lastrun2now
+from drgn_tools.util import timestamp_str
 
 # List runqueus per cpu
 
@@ -65,20 +67,31 @@ def _print_cfs_runq(runqueue: Object) -> None:
         print("     [no tasks queued]")
 
 
-def run_queue(prog: Program) -> None:
+def run_queue(prog: Program, min_run_time_seconds: int = 0) -> None:
     """
-    Print tasks which are in the RT and CFS runqueues on each CPU
+    Print tasks which are in the RT and CFS runqueues on each CPU. Specify min_run_time_seconds to x to only print
+    processes running more than x seconds.
+
+    :param prog: drgn program
+    :param min_run_time_seconds: int
     """
 
     # _cpu = drgn.helpers.linux.cpumask.for_each_online_cpu(prog)
     for cpus in for_each_online_cpu(prog):
         runqueue = per_cpu(prog["runqueues"], cpus)
-        comm = escape_ascii_string(runqueue.curr.comm.string_())
-        pid = runqueue.curr.pid.value_()
+        curr_task_addr = runqueue.curr.value_()
+        curr_task = runqueue.curr[0]
+        comm = escape_ascii_string(curr_task.comm.string_())
+        pid = curr_task.pid.value_()
+        run_time = task_lastrun2now(curr_task)
+        prio = curr_task.prio.value_()
+        if run_time < min_run_time_seconds * 1e9:
+            continue
         print(f"CPU {cpus} RUNQUEUE: {runqueue.address_of_().value_():x}")
         print(
-            f"  CURRENT:   PID: {pid:<6d}  TASK: {runqueue.curr.value_():x}"
-            f'  COMMAND: "{comm}"',
+            f"  CURRENT:   PID: {pid:<6d}  TASK: {curr_task_addr:x}  PRIO: {prio}"
+            f'  COMMAND: "{comm}"'
+            f"  RUNTIME: {timestamp_str(run_time)}",
         )
         # RT PRIO_ARRAY
         _print_rt_runq(runqueue)


### PR DESCRIPTION
Dump prio and runtime as well. Removed  min_run_time_seconds parameter since we have another lockup helper pending to merge.