### PR TITLE
Lock improvements

### DIFF
--- a/drgn_tools/lock.py
+++ b/drgn_tools/lock.py
@@ -148,15 +148,18 @@ def scan_mutex_lock(
         struct_owner = mutex_owner(prog, mutex)
         index = 0
         print(f"Mutex: 0x{mutex_addr:x}")
-        print(
-            "Mutex OWNER:",
-            struct_owner.comm.string_().decode("utf-8"),
-            "PID :",
-            struct_owner.pid.value_(),
-        )
-        if stack:
-            bt(struct_owner)
-            print("")
+        if struct_owner:
+            print(
+                "Mutex OWNER:",
+                struct_owner.comm.string_().decode("utf-8"),
+                "PID :",
+                struct_owner.pid.value_(),
+            )
+            if stack:
+                bt(struct_owner)
+                print("")
+        else:
+            print("Mutex OWNER: NULL")
 
         print(
             "Mutex WAITERS (Index, cpu, comm, pid, state, wait time (d hr:min:sec:ms)):"


### PR DESCRIPTION
One fix for mutexes, and then an enhancement to the printing for the locks, so that they print the symbol name or slab cache they came from. EG:

```
Scanning Mutexes...

Mutex: 0xffffffffc0e380a0 (object symbol: lockmod_mutex+0x0)
Mutex OWNER: lockmod-owner PID : 8933
Mutex WAITERS (Index, cpu, comm, pid, state, wait time (d hr:min:sec:ms)):
         [1]: cpu: 0    lockmod-mutex_l  8934     D      0 00:00:06.761  
         [2]: cpu: 0    lockmod-mutex_l  8935     D      0 00:00:06.761  
         [3]: cpu: 0    lockmod-mutex_l  8936     D      0 00:00:06.761  
         [4]: cpu: 0    lockmod-mutex_l  8937     D      0 00:00:06.761  
         [5]: cpu: 0    lockmod-mutex_l  8938     D      0 00:00:06.761  
         [6]: cpu: 0    lockmod-mutex_l  8939     D      0 00:00:06.761  
         [7]: cpu: 0    lockmod-mutex_l  8940     S      0 00:00:06.761  
         [8]: cpu: 0    lockmod-mutex_l  8941     S      0 00:00:06.761  

Scanning Semaphores...

Semaphore: 0xffffffffc0e38040 (object symbol: lockmod_sem+0x0)
Semaphore WAITERS (Index, cpu, comm, pid, state, wait time (d hr:min:sec:ms)):
         [1]: cpu: 0    lockmod-sem_dow  8942     D      0 00:00:06.761  
         [2]: cpu: 0    lockmod-sem_dow  8943     S      0 00:00:06.761  
         [3]: cpu: 0    lockmod-sem_dow  8944     D      0 00:00:06.761  
         [4]: cpu: 0    lockmod-sem_dow  8945     D      0 00:00:06.761  

Scanning RWSemaphores...

Rwsem: 0xffffffffc0e38060 (object symbol: lockmod_rwsem+0x0)
rwsem has no spinners.
Writer owner (struct task_struct *)0xff4ceaeac8bba080: (pid)8933
Rwsem WAITERS (Index, cpu, comm, pid, state, type, wait time (d hr:min:sec:ms)):
         [1]: cpu: 0    lockmod-rwsem_d  8946     D      0 00:00:06.761  
         [2]: cpu: 1    lockmod-rwsem_d  8947     D      0 00:00:06.765  
         [3]: cpu: 1    lockmod-rwsem_d  8948     S      0 00:00:06.765  
         [4]: cpu: 0    lockmod-rwsem_d  8949     D      0 00:00:06.761  
         [5]: cpu: 0    lockmod-rwsem_d  8950     D      0 00:00:06.761  
         [6]: cpu: 0    lockmod-rwsem_d  8951     D      0 00:00:06.761  
         [7]: cpu: 0    lockmod-rwsem_d  8952     D      0 00:00:06.761  
         [8]: cpu: 0    lockmod-rwsem_d  8953     D      0 00:00:06.761  
         [9]: cpu: 0    lockmod-rwsem_d  8954     D      0 00:00:06.761 
```