### PR TITLE
ls: Add support to recursively print dentries of subdirectories

### DIFF
--- a/tests/test_dentry.py
+++ b/tests/test_dentry.py
@@ -17,4 +17,4 @@ def test_list_dentries_in_hashtable(prog):
 
 
 def test_ls(prog):
-    dentry.ls(prog, "/")
+    dentry.ls(prog, "/", None, 0)


### PR DESCRIPTION
Currently, ls module prints the dentries of a given directory. Add support to print the dentries of its subdirectories recursively up to a specified depth.

Signed-off-by: Srivathsa Dara <srivathsa.d.dara@oracle.com>