### PR TITLE
dm: handle NULL hc.uuid

### DIFF
--- a/drgn_tools/dm.py
+++ b/drgn_tools/dm.py
@@ -26,14 +26,22 @@ def for_each_dm_hash(prog: Program) -> Iterable[Tuple[Object, str, str]]:
         for hc in list_for_each_entry(
             "struct hash_cell", head.address_of_(), "name_list"
         ):
-            yield hc.md, hc.name.string_().decode(), hc.uuid.string_().decode()
+            uuid = ""
+            if hc.uuid:
+                uuid = hc.uuid.string_().decode()
+
+            yield hc.md, hc.name.string_().decode(), uuid
 
 
 def for_each_dm_rbtree(prog: Program) -> Iterable[Tuple[Object, str, str]]:
     for hc in rbtree_inorder_for_each_entry(
         "struct hash_cell", prog["name_rb_tree"], "name_node"
     ):
-        yield hc.md, hc.name.string_().decode(), hc.uuid.string_().decode()
+        uuid = ""
+        if hc.uuid:
+            uuid = hc.uuid.string_().decode()
+
+        yield hc.md, hc.name.string_().decode(), uuid
 
 
 def for_each_dm(prog: Program) -> Iterable[Tuple[Object, str, str]]:


### PR DESCRIPTION
fix:
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/usr/lib/python3.6/site-packages/drgn_tools/dm.py", line 97, in show_dm
    for dm, name, uuid in for_each_dm(prog):
  File "/usr/lib/python3.6/site-packages/drgn_tools/dm.py", line 29, in for_each_dm_hash
    yield hc.md, hc.name.string_().decode(), hc.uuid.string_().decode()
_drgn.FaultError: could not read memory from kdump: Cannot get page I/O address: PML4 table not present: pgd[0] = 0x0: 0x0 