### PR TITLE
UEK-NEXT support

### DIFF
--- a/drgn_tools/bt.py
+++ b/drgn_tools/bt.py
@@ -120,12 +120,9 @@ def find_pt_regs(trace: drgn.StackTrace) -> t.Optional[drgn.Object]:
             except KeyError:
                 continue
             except Exception as e:
-                # In this case, drgn misbehaves on a type of DWARF opcode
-                # which it couldn't handle anyway. The proper way to handle
-                # it is to treat it as an absent variable. Normally, we
-                # still print absent variables (since it helps to have their
-                # type info). In this case we'll just bite the bullet and
-                # skip printing the variable altogether.
+                # When drgn doesn't understand a DWARF expression opcode, it
+                # raises this error. Some instances of this have been caught and
+                # fixed, but in general this catch is a good thing to keep.
                 # https://github.com/osandov/drgn/issues/233
                 # https://github.com/osandov/drgn/issues/374
                 if "unknown DW" in str(e):
@@ -357,23 +354,18 @@ def print_frames(
                     )
                 )
 
-        # This requires drgn 0.0.22+.
         for local in frame.locals():
             try:
                 val = frame[local]
             except KeyError:
                 continue
             except Exception as e:
-                # In this case, drgn misbehaves on a type of DWARF opcode
-                # which it couldn't handle anyway. The proper way to handle
-                # it is to treat it as an absent variable. Normally, we
-                # still print absent variables (since it helps to have their
-                # type info). In this case we'll just bite the bullet and
-                # skip printing the variable altogether.
-                # TODO: when v0.0.23 is released, assuming it contains
-                # the fix for the below bug, drop this exception handler.
+                # When drgn doesn't understand a DWARF expression opcode, it
+                # raises this error. Some instances of this have been caught and
+                # fixed, but in general this catch is a good thing to keep.
                 # https://github.com/osandov/drgn/issues/233
-                if "unknown DWARF expression opcode" in str(e):
+                # https://github.com/osandov/drgn/issues/374
+                if "unknown DW" in str(e):
                     continue
                 else:
                     raise

--- a/drgn_tools/crash_net.py
+++ b/drgn_tools/crash_net.py
@@ -19,6 +19,7 @@ from drgn.helpers.linux.pid import find_task
 
 from drgn_tools.corelens import CorelensModule
 from drgn_tools.table import print_table
+from drgn_tools.task import task_cpu
 
 _NETDEV_HASHBITS = 8
 _NETDEV_HASHENTRIES = 1 << _NETDEV_HASHBITS
@@ -266,7 +267,7 @@ def print_task_sockets(prog: Program, pid: int, print_full_data: bool) -> None:
         + "    TASK: "
         + hex(task.value_())[2:]
         + "    CPU: "
-        + str(int(task.cpu))
+        + str(task_cpu(task))
         + "    COMMAND: "
         + task.comm.string_().decode("utf-8")
     )

--- a/drgn_tools/dentry.py
+++ b/drgn_tools/dentry.py
@@ -80,6 +80,8 @@ def dentry_path_any_mount(dentry: Object) -> bytes:
 
     :param dentry: ``struct dentry *``
     """
+    # TODO: drgn 0.0.29: this can be replaced with d_path()
+    # See osandov/drgn#426.
     dentry = dentry.read_()
     d_op = dentry.d_op.read_()
     if d_op and d_op.d_dname:

--- a/drgn_tools/device.py
+++ b/drgn_tools/device.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2024, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+"""
+Helpers for working with the Linux kernel device model
+"""
+from drgn import Object
+from drgn.helpers.linux.list import list_for_each_entry
+
+
+def bus_to_subsys(bus_type: Object) -> Object:
+    """
+    Return the ``struct subsys_private *`` corresponding to a
+    ``struct bus_type *``. See the kernel function of the same name.
+    """
+    if hasattr(bus_type, "p"):
+        return bus_type.p
+
+    # Since v6.3, commit d2bf38c088e0d ("driver core: remove private pointer
+    # from struct bus_type"), the private pointer is gone. We now need to lookup
+    # subsys_private by iterating over the bus list and finding the one related
+    # to this.
+    bus_kset = bus_type.prog_["bus_kset"]
+    for subsys in list_for_each_entry(
+        "struct subsys_private",
+        bus_kset.list.address_of_(),
+        "subsys.kobj.entry",
+    ):
+        if subsys.bus == bus_type:
+            return subsys
+    bus_name = bus_type.name.string_().decode()
+    raise ValueError(f"Could not find subsys_private for bus_type {bus_name}")
+
+
+def class_to_subsys(class_: Object) -> Object:
+    """
+    Return the ``struct subsys_private *`` corresponding to a
+    ``struct class *``. See the kernel function of the same name.
+    """
+    if hasattr(class_, "p"):
+        return class_.p
+
+    # Since v6.4, commit 2df418cf4b720 ("driver core: class: remove subsystem
+    # private pointer from struct class"), the private pointer is gone. We now
+    # need to lookup subsys_private by iterating over the class list and finding
+    # the one related to this.
+    class_kset = class_.prog_["class_kset"]
+    for subsys in list_for_each_entry(
+        "struct subsys_private",
+        class_kset.list.address_of_(),
+        "subsys.kobj.entry",
+    ):
+        if subsys.member_("class") == class_:
+            return subsys
+    class_name = class_.name.string_().decode()
+    raise ValueError(f"Could not find subsys_private for class {class_name}")

--- a/drgn_tools/fsnotify.py
+++ b/drgn_tools/fsnotify.py
@@ -125,6 +125,11 @@ def fsnotify_mark_object(mark: Object) -> Tuple[str, Object]:
         # object"), there were direct pointers in the connector.
         if hasattr(conn, "inode"):
             return "inode", conn.inode
+        elif conn.obj.type_.type_name() == "void *":
+            # Since 687c217c6aa2 ("fsnotify: pass object pointer and type to
+            # fsnotify mark helpers"), the "obj" pointer is just a plain pointer
+            # to the object in question.
+            return "inode", cast("struct inode *", conn.obj)
         return "inode", container_of(
             conn.obj, "struct inode", "i_fsnotify_marks"
         )
@@ -133,6 +138,12 @@ def fsnotify_mark_object(mark: Object) -> Tuple[str, Object]:
         # object"), there were direct pointers in the connector.
         if hasattr(conn, "vfsmount"):
             return "vfsmount", conn.vfsmount
+        elif conn.obj.type_.type_name() == "void *":
+            # Since 687c217c6aa2 ("fsnotify: pass object pointer and type to
+            # fsnotify mark helpers"), the "obj" pointer is just a plain pointer
+            # to the struct vfsmount, which we still need to turn into a struct
+            # mount.
+            return "vfsmount", container_of(conn.obj, "struct mount", "mnt")
         return "vfsmount", container_of(
             conn.obj, "struct mount", "mnt_fsnotify_marks"
         )
@@ -140,6 +151,12 @@ def fsnotify_mark_object(mark: Object) -> Tuple[str, Object]:
         # The "sb" object type was not present when 36f10f55ff1d2 ("fsnotify:
         # let connector point to an abstract object") so it will never have an
         # "sb" field.
+        if conn.obj.type_.type_name() == "void *":
+            # Since 687c217c6aa2 ("fsnotify: pass object pointer and type to
+            # fsnotify mark helpers"), the "obj" pointer is just a plain pointer
+            # to the struct vfsmount, which we still need to turn into a struct
+            # mount.
+            return "sb", cast("struct super_block *", conn.obj)
         return "sb", container_of(
             conn.obj, "struct super_block", "s_fsnotify_marks"
         )

--- a/drgn_tools/lsmod.py
+++ b/drgn_tools/lsmod.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, Oracle and/or its affiliates.
+# Copyright (c) 2024, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 import argparse
 from typing import Iterable
@@ -83,7 +83,7 @@ def print_module_summary(prog: Program) -> None:
             [
                 hex(mod.obj.value_()),
                 mod.name,
-                str(mod.address_region().total_size),
+                str(mod.mem_usage()),
                 str(int(mod.obj.refcnt.counter)),
                 ",".join(dep_mod),
             ]

--- a/drgn_tools/module.py
+++ b/drgn_tools/module.py
@@ -1,5 +1,6 @@
-# Copyright (c) 2023, Oracle and/or its affiliates.
+# Copyright (c) 2024, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+import operator
 from collections import defaultdict
 from pathlib import Path
 from typing import Dict
@@ -14,6 +15,7 @@ from typing import Union
 from drgn import cast
 from drgn import FaultError
 from drgn import IntegerLike
+from drgn import NULL
 from drgn import Object
 from drgn import Program
 from drgn import sizeof
@@ -21,6 +23,7 @@ from drgn import Symbol
 from drgn import SymbolBinding
 from drgn import SymbolKind
 from drgn.helpers.linux.list import list_for_each_entry
+from drgn.helpers.linux.rbtree import rb_find
 
 try:
     # drgn v0.21.0+
@@ -36,17 +39,15 @@ from drgn_tools.taint import Taint
 
 __all__ = (
     "KernelModule",
-    "ModuleLayout",
     "ParamInfo",
     "address_to_module",
     "ensure_debuginfo",
     "find_module",
     "for_each_module",
     "load_module_debuginfo",
-    "module_address_region",
+    "module_address_regions",
     "module_build_id",
     "module_exports",
-    "module_init_region",
     "module_params",
     "module_percpu_region",
     "module_symbols",
@@ -54,210 +55,211 @@ __all__ = (
 )
 
 
-class ModuleLayout(NamedTuple):
-    """
-    Represents a module's layout in memory.
-
-    Module memory layout is organized into three sections. First is the text
-    section, which is read-only (RO). Next is the RO data section, which is
-    usually protected with no-execute (NX) permissions. Next is additional
-    data which becomes RO after init, and finally is the RW data. The below
-    diagram from the kernel source code demonstrates this layout (note that
-    for clarity, we refer to ``size`` as ``total_size``).
-
-    .. code-block::
-
-      General layout of module is:
-               [text] [read-only-data] [ro-after-init] [writable data]
-      text_size -----^                ^               ^               ^
-      ro_size ------------------------|               |               |
-      ro_after_init_size -----------------------------|               |
-      size -----------------------------------------------------------|
-    """
-
-    base: Object
-    """The base address of the memory region, as a ``void *``."""
-    total_size: int
-    """The total length of the memory region."""
-    text_size: int
-    """The length of the text section."""
-    ro_size: int
-    """The length of the read-only memory (text, and RO data)"""
-    ro_after_init_size: int
-    """The length of the read-only memory, plus memory which is RO after init"""
-
-    def contains(self, address: IntegerLike) -> bool:
-        offset = int(address) - self.base.value_()
-        return 0 <= offset < self.total_size
-
-
-def _layout_from_module_layout(layout: Object) -> ModuleLayout:
-    try:
-        ro_after_init_size = layout.ro_after_init_size.value_()
-    except AttributeError:
-        # Prior to 4.8, 444d13ff10fb ("modules: add ro_after_init support"),
-        # there was no ro_after_init support. Pretend it existed and it was
-        # just zero-length.
-        ro_after_init_size = layout.ro_size.value_()
-    return ModuleLayout(
-        layout.base,
-        layout.size.value_(),
-        layout.text_size.value_(),
-        layout.ro_size.value_(),
-        ro_after_init_size,
-    )
-
-
-def _layout_from_module(module: Object, kind: str) -> ModuleLayout:
-    return ModuleLayout(
-        module.member_(f"module_{kind}"),
-        module.member_(f"{kind}_size").value_(),
-        module.member_(f"{kind}_text_size").value_(),
-        module.member_(f"{kind}_ro_size").value_(),
-        module.member_(f"{kind}_ro_size").value_(),
-    )
-
-
-def module_address_region(mod: Object) -> ModuleLayout:
-    """
-    Lookup the core memory region of a module.
-
-    Given a ``struct module *``, return the address and length of its code and
-    data. This region ignores the "__init" data of the module; see
-
-    :func: ``module_init_region()`` to find that.
-    :param mod: Object of type ``struct module *``
-    :returns: A tuple representing the address and size of the memory, along
-      with the size of various protection zones within.
-    """
-    try:
-        return _layout_from_module_layout(mod.core_layout)
-    except AttributeError:
-        # Prior to 4.5, 7523e4dc5057 ("module: use a structure to encapsulate
-        # layout."), the layout information was stored as plain fields on the
-        # module.
-        return _layout_from_module(mod, "core")
-
-
-def module_init_region(mod: Object) -> Optional[ModuleLayout]:
-    """
-    Lookup the init memory region of a module.
-
-    Given a ``struct module *``, return the address and length of the
-    ``__init`` memory regions. This memory is typically freed after the module
-    is loaded, so under most circumstances, this will return None.
-
-    :param mod: Object of type ``struct module *``
-    :returns: A tuple representing the layout of the init memory
-    """
-    try:
-        layout = _layout_from_module_layout(mod.init_layout)
-    except AttributeError:
-        layout = _layout_from_module(mod, "init")
-    if not layout.base.value_():
-        return None
-    return layout
-
-
-def module_percpu_region(mod: Object) -> Optional[Tuple[Object, int]]:
-    """
-    Lookup the percpu memory region of a module.
-
-    Given a ``struct module *``, return the address and the length of the
-    percpu memory region. Modules may have a NULL percpu region, in which case
-    ``(void *)NULL`` is returned. Rarely, on kernels without ``CONFIG_SMP``,
-    there is no percpu region at all, and this function returns ``None``.
-
-    :param mod: Object of type ``struct module *``
-    :returns: A tuple containing the base address and length of the region
-    """
-    try:
-        return mod.percpu, mod.percpu_size.value_()
-    except AttributeError:
-        return None
-
-
 def for_each_module(prog: Program) -> Iterable[Object]:
     """
-    Get all loaded kernel module objects in kernel
+    Returns all loaded kernel modules
 
-    :param prog: Program being debugged
     :returns: Iterable of ``struct module *`` objects
     """
+    # TODO: drgn 0.0.28: upstreamed to drgn.helpers.linux.module
     return list_for_each_entry(
         "struct module", prog["modules"].address_of_(), "list"
     )
 
 
-def find_module(prog: Program, name: Union[str, bytes]) -> Optional[Object]:
+def find_module(prog: Program, name: Union[str, bytes]) -> Object:
     """
-    Return the module with the given name
-    :param name: Module name
-    :returns: if found, ``struct module *``
+    Lookup a kernel module by name, or return NULL if not found
+
+    :param name: name to search for
+    :returns: the ``struct module *`` by that name, or NULL
     """
+    # TODO: drgn 0.0.28: upstreamed to drgn.helpers.linux.module
     if isinstance(name, str):
         name = name.encode()
     for module in for_each_module(prog):
         if module.name.string_() == name:
             return module
-    return None
+    return NULL(prog, "struct module *")
 
 
-@overload
-def address_to_module(addr: Object) -> Optional[Object]:
-    """"""
-    ...
-
-
-@overload
-def address_to_module(prog: Program, addr: IntegerLike) -> Optional[Object]:
-    ...
-
-
-def address_to_module(  # type: ignore  # Need positional-only arguments.
-    prog_or_addr: Union[Program, Object],
-    addr: Optional[IntegerLike] = None,
-) -> Optional[Object]:
+def module_percpu_region(mod: Object) -> Tuple[int, int]:
     """
-    Try to find the module corresponding to a memory address.
+    Lookup the percpu memory region of a module.
 
-    Search for the given address in the list of loaded kernel modules. If it
-    is within the address range corresponding to a kernel module, return that
-    module. This function searches the module's core (normal memory) region,
-    the module's init region (if present) and the module's percpu region (if
-    present). Note that it's impossible to detect memory **allocated** by a
-    particular kernel module: this function only deals with static data.
+    Given a ``struct module *``, return the address (as a an int) and the length
+    of the percpu memory region. Modules may have a NULL percpu region, in which
+    case (0, 0) is returned. Rarely, on kernels without ``CONFIG_SMP``, there is
+    no percpu region at all, and this function returns (0, 0)
 
-    This helper performs a linear search of the list of modules, which could
-    grow quite large. As a result, the performance may suffer on repeated
-    lookups.
-
-    :param addr: address to lookup
-    :returns: if the address corresponds to a module, ``struct module *``
+    :param mod: Object of type ``struct module *``
+    :returns: (base, size) of the module percpu region
     """
-    if addr is None:
-        assert isinstance(prog_or_addr, Object)
-        prog = prog_or_addr.prog_
-        addr = prog_or_addr.value_()
+    # TODO: drgn 0.0.28: upstreamed to drgn.helpers.linux.module
+    try:
+        return mod.percpu.value_(), mod.percpu_size.value_()
+    except AttributeError:
+        return 0, 0
+
+
+def _range_from_module_layout(layout: Object) -> Tuple[int, int]:
+    # TODO: drgn 0.0.28: upstreamed to drgn.helpers.linux.module
+    # For "struct module_layout" (old) or "struct module_memory"
+    return layout.base.value_(), layout.size.value_()
+
+
+def _range_from_module(module: Object, kind: str) -> Tuple[int, int]:
+    # TODO: drgn 0.0.28: upstreamed to drgn.helpers.linux.module
+    # For reading a range directly from "struct module" (old kernels)
+    return (
+        module.member_(f"module_{kind}").value_(),
+        module.member_(f"{kind}_size").value_(),
+    )
+
+
+def _ranges_from_module_memory(mod: Object) -> List[Tuple[int, int]]:
+    # TODO: drgn 0.0.28: upstreamed to drgn.helpers.linux.module
+    # For reading all ranges from a modules "struct module_memory"
+    return [_range_from_module_layout(mem) for mem in mod.mem]
+
+
+def module_address_regions(mod: Object) -> List[Tuple[int, int]]:
+    """
+    Returns a list of address ranges for a module
+
+    Given a ``struct module *``, return every address range associated with the
+    module. Note that the number of address ranges and their interpretations
+    vary across kernel versions. Some kernel versions provide additional
+    information about some regions (e.g. text, data, R/O, init). This API
+    doesn't distinguish. However, this API does not provide the module's percpu
+    region: use ``module_percpu_region()`` for that.
+
+    :param mod: Object of type ``struct module *``
+    :returns: list of tuples: (starting memory address, length of address range)
+    """
+    # TODO: drgn 0.0.28: upstreamed to drgn.helpers.linux.module
+    try:
+        # Since Linux 6.4, ac3b432839234 ("module: replace module_layout with
+        # module_memory"), module address regions are broken into several types,
+        # each with their own base and size.
+        mod.prog_.constant("MOD_MEM_NUM_TYPES")
+    except LookupError:
+        pass
     else:
-        assert isinstance(prog_or_addr, Program)
-        prog = prog_or_addr
-        addr = int(addr)
+        return _ranges_from_module_memory(mod)
+
+    try:
+        # Prior to 6.4, there were two "struct module_layout" objects,
+        # core_layout and init_layout, which contained the module's memory
+        # layout and any memory which could be freed after init. The init_layout
+        # is usually NULL / size 0. The module_layout structure has more
+        # information to say where text ends, where rodata ends, etc. We ignore
+        # these.
+        core = _range_from_module_layout(mod.core_layout)
+        init = _range_from_module_layout(mod.init_layout)
+    except AttributeError:
+        # Prior to 4.5, 7523e4dc5057 ("module: use a structure to encapsulate
+        # layout."), the layout information was stored as variables directly in
+        # the struct module. They were prefixed with "core_" and "init_".
+        core = _range_from_module(mod, "core")
+        init = _range_from_module(mod, "init")
+
+    ret = [core]
+    if init:
+        ret.append(init)
+    return ret
+
+
+def _addrmod_tree(mod_tree: Object, addr: int) -> Object:
+    # TODO: drgn 0.0.28: upstreamed to drgn.helpers.linux.module
+    prog = mod_tree.prog_
+
+    # The module tree is "latched": there are two parallel trees. Which one is
+    # in use depends on the seqcount, which gets incremented for each
+    # modification. This is a really neat approach that allows reads in parallel
+    # with a writer. In our use case, it's probably not worth verifying the
+    # seqcount after the fact. What we do need is the index (0 or 1). This may
+    # be a seqcount_latch_t, or before 24bf401cebfd6 ("rbtree_latch: Use
+    # seqcount_latch_t"), a regular seqcount_t.
+    try:
+        idx = mod_tree.root.seq.seqcount.sequence.value_() & 1
+    except AttributeError:
+        idx = mod_tree.root.seq.sequence.value_() & 1
+
+    # In ac3b432839234 ("module: replace module_layout with module_memory"),
+    # struct module_layout was replaced by module_memory. The module_layout
+    # encoded the separate regions (text, data, rodata, etc) in a single
+    # structure, whereas module_memory is a simple base pointer followed by a
+    # size: one module_memory structure is used per kind of memory. However,
+    # both of them contain a "base" pointer that indicates the start of the
+    # region, a "size" that indicates its total size, and a "mtn.mod" pointer
+    # which refers to the relevant module. So for our use case, they are
+    # interchangeable, except for their names.
+    try:
+        tp = prog.type("struct module_memory")
+    except LookupError:
+        tp = prog.type("struct module_layout")
+
+    def cmp(v: int, node: Object) -> int:
+        start = node.base.value_()
+        end = start + node.size.value_()
+        if v < start:
+            return -1
+        elif v >= end:
+            return 1
+        else:
+            return 0
+
+    mem = rb_find(
+        tp,
+        mod_tree.root.tree[idx].address_of_(),
+        f"mtn.node.node[{idx}]",  # container_of allows array indices!
+        addr,
+        cmp,
+    )
+    if mem:
+        return mem.mtn.mod
+    else:
+        return NULL(prog, "struct module *")
+
+
+def address_to_module(prog: Program, addr: IntegerLike) -> Object:
+    """
+    Return the ``struct module *`` associated with a memory address
+
+    If the address is a text, data, or read-only data address associated with a
+    kernel module, then this function returns the module it is associated with.
+    Otherwise, returns NULL. Note that dynamic memory (e.g. slab objects)
+    generally can't be associated with the module that allocated it. Further,
+    static & dynamic per-cpu address cannot be associated with their associated
+    module either.
+
+    Normally, this lookup is efficient, thanks to
+    ``CONFIG_MODULES_TREE_LOOKUP``, which provides a red-black tree of module
+    address ranges, and is `very commonly`__ enabled. However, on some uncommon
+    configurations the rbtree may not be present. In those cases, we fall back
+    to a linear search of each kernel module's memory regions.
+
+    .. __: https://oracle.github.io/kconfigs/?config=MODULES_TREE_LOOKUP&config=UTS_RELEASE
+
+    :param addr: memory address to lookup
+    :returns: the ``struct module *`` associated with the memory, or NULL
+    """
+    # TODO: drgn 0.0.28: upstreamed to drgn.helpers.linux.module
+    addr = operator.index(addr)
+    try:
+        mod_tree = prog["mod_tree"]
+    except LookupError:
+        pass
+    else:
+        return _addrmod_tree(mod_tree, addr)
 
     for module in for_each_module(prog):
-        region = module_address_region(module)
-        if region.contains(addr):
-            return module
-        pcpu_region = module_percpu_region(module)
-        if pcpu_region:
-            pcpu, pcpu_len = pcpu_region
-            if 0 <= addr - pcpu.value_() < pcpu_len:
+        for start, length in module_address_regions(module):
+            if start <= addr < start + length:
                 return module
-        init_region = module_init_region(module)
-        if init_region and init_region.contains(addr):
-            return module
 
-    return None
+    return NULL(prog, "struct module *")
 
 
 def module_build_id(mod: Object) -> str:
@@ -643,29 +645,12 @@ def module_unified_symbols(module: Object) -> List[Tuple[str, int, int]]:
     # One strategy for finding the end of a symbol is noticing that it is within
     # a module address region, and realizing that it should not stretch past it.
     # Implement the strategy here.
-    core_layout = module_address_region(module)
-    init_layout = module_init_region(module)
-    percpu_layout = module_percpu_region(module)
-    layouts: List[Optional[ModuleLayout]] = [
-        core_layout,
-        init_layout,
-    ]
+    regions = module_address_regions(module)
 
     def find_end_scn(addr: int) -> Optional[int]:
-        for layout in layouts:
-            if not layout or not layout.contains(addr):
-                continue
-            for kind in ("text", "ro", "ro_after_init", "total"):
-                boundary = layout.base.value_() + getattr(
-                    layout, f"{kind}_size"
-                )
-                if addr < boundary:
-                    return boundary
-            assert False, "Impossible to reach this line"
-        if percpu_layout is not None:
-            pcpu_reg, pcpu_len = percpu_layout
-            if addr >= pcpu_reg and addr < pcpu_reg + pcpu_len:
-                return pcpu_reg + pcpu_len
+        for start, size in regions:
+            if start <= addr < start + size:
+                return start + size
         return None
 
     # Iterate over each symbol, and if the length is missing, try to infer.
@@ -796,13 +781,8 @@ class KernelModule:
     >>> km = KernelModule.find(prog, "nf_nat")
     >>> km
     KernelModule(nf_nat)
-    >>> km.address_region()
-    ModuleLayout(base=Object(prog, 'void *', address=0xffffffffc0878580), total_size=40960, text_size=16384, ro_size=20480, ro_after_init_size=24576)
-    >>> km.init_region()
-    >>> km.percpu_region()
-    (Object(prog, 'void *', address=0xffffffffc0878688), 0)
-    >>> hex(km.address_region().base + 123)
-    '0xffffffffc087207b'
+    >>> km.address_regions()
+    [(Object(prog, 'void *', address=0xffffffffc0878688), 0)]
     >>> KernelModule.lookup_address(prog, 0xffffffffc087207b)
     KernelModule(nf_nat)
     """
@@ -830,9 +810,7 @@ class KernelModule:
         :returns: Iterable of kernel module helpers
         """
         maybe_mod = find_module(prog, name)
-        if maybe_mod:
-            maybe_mod = KernelModule(maybe_mod)
-        return maybe_mod
+        return KernelModule(maybe_mod) if maybe_mod.value_() != 0 else None
 
     @classmethod
     @overload
@@ -915,20 +893,20 @@ class KernelModule:
             else:
                 raise FileNotFoundError("Could not find debuginfo for module")
 
-    def address_region(self) -> ModuleLayout:
+    def address_regions(self) -> List[Tuple[int, int]]:
         """
         Return the core region of the module. See
         :func:`module_address_region()`.
 
         :returns: Layout of the "core" (non-init) region
         """
-        return module_address_region(self.obj)
+        return module_address_regions(self.obj)
 
-    def init_region(self) -> Optional[ModuleLayout]:
+    def mem_usage(self) -> int:
         """
-        Return the init memory region of the module.
+        Return the sum of the memory usage of this module.
         """
-        return module_init_region(self.obj)
+        return sum(r[1] for r in self.address_regions())
 
     def percpu_region(self) -> Optional[Tuple[Object, int]]:
         """

--- a/drgn_tools/module.py
+++ b/drgn_tools/module.py
@@ -22,15 +22,9 @@ from drgn import sizeof
 from drgn import Symbol
 from drgn import SymbolBinding
 from drgn import SymbolKind
+from drgn.helpers.common import escape_ascii_string
 from drgn.helpers.linux.list import list_for_each_entry
 from drgn.helpers.linux.rbtree import rb_find
-
-try:
-    # drgn v0.21.0+
-    from drgn.helpers.common import escape_ascii_string
-except ImportError:
-    # drgn <v0.21.0
-    from drgn.helpers import escape_ascii_string
 
 from drgn_tools.debuginfo import fetch_debuginfo
 from drgn_tools.debuginfo import find_debuginfo

--- a/drgn_tools/mounts.py
+++ b/drgn_tools/mounts.py
@@ -22,14 +22,17 @@ def get_mountinfo(prog: drgn.Program) -> List[List[str]]:
     mounts = prog["init_task"].nsproxy.mnt_ns
     for mnt in drgn.helpers.linux.fs.for_each_mount(mounts):
         devname = mnt.mnt_devname
-        fstype = mnt.mnt.mnt_sb.s_type.name
+        sb = mnt.mnt.mnt_sb
+        fstype = sb.s_type.name.string_()
+        if sb.s_subtype:
+            fstype += b"." + sb.s_subtype.string_()
         mntpt = drgn.helpers.linux.fs.d_path(
             mnt.mnt_parent.mnt.address_of_(), mnt.mnt_mountpoint
         )
 
         mount_stats = [
             devname.string_().decode("utf-8"),
-            fstype.string_().decode("utf-8"),
+            fstype.decode("utf-8"),
             mntpt.decode("utf-8"),
         ]
         mount_table.append(mount_stats)

--- a/drgn_tools/numastat.py
+++ b/drgn_tools/numastat.py
@@ -140,8 +140,13 @@ def get_per_node_meminfo(prog: Program, node: Object) -> Dict[str, int]:
         mm_consts["PAGE_SHIFT"] - 10
     )
     mm_stats["PageTables"] = node_zone_stats["NR_PAGETABLE"]
+
+    # ebc97a52b5d6c ("mm: add NR_SECONDARY_PAGETABLE to count secondary page
+    # table uses.")
+    if "NR_SECONDARY_PAGETABLE" in node_zone_stats:
+        mm_stats["SecPageTables"] = node_zone_stats["NR_SECONDARY_PAGETABLE"]
     mm_stats["NFS_Unstable"] = 0
-    if "NR_UNSTABLE_NFS" in mm_stats:
+    if "NR_UNSTABLE_NFS" in node_zone_stats:
         mm_stats["NFS_Unstable"] = node_zone_stats["NR_UNSTABLE_NFS"]
     mm_stats["Bounce"] = bounce_pages
     mm_stats["WritebackTmp"] = node_zone_stats["NR_WRITEBACK_TEMP"]
@@ -170,6 +175,10 @@ def get_per_node_meminfo(prog: Program, node: Object) -> Dict[str, int]:
         mm_stats["ShmemPmdMapped"] = -1
         mm_stats["FileHugePages"] = -1
         mm_stats["FilePmdMapped"] = -1
+
+    # dcdfdd40fa82b ("mm: Add support for unaccepted memory")
+    if "NR_UNACCEPTED" in node_zone_stats:
+        mm_stats["Unaccepted"] = node_zone_stats["NR_UNACCEPTED"]
 
     # Collect hugepage info for the default hugepage size in this node.
     node_id = node.node_id.value_()

--- a/drgn_tools/nvme.py
+++ b/drgn_tools/nvme.py
@@ -48,12 +48,19 @@ def show_ns_info(prog: Program) -> None:
         else:
             refcount = nvme_ns.kref.refcount.counter.value_()
 
+        # In commit b4c1f33a5d59 ("nvme: reorganize nvme_ns_head fields"),
+        # pi_type was moved to the nvme_ns_head structure.
+        if hasattr(nvme_ns, "pi_type"):
+            pi_type = nvme_ns.pi_type.value_()
+        else:
+            pi_type = nvme_ns.head.pi_type.value_()
+
         rows.append(
             [
                 nvme_ns.disk.disk_name.string_().decode(),
                 "{:x}".format(nvme_ns.value_()),
                 refcount,
-                nvme_ns.pi_type.value_(),
+                pi_type,
                 nvme_ns.flags.value_(),
             ]
         )

--- a/drgn_tools/partition.py
+++ b/drgn_tools/partition.py
@@ -76,6 +76,17 @@ def get_partinfo_from_hd_struct(part: Object) -> PartInfo:
     )
 
 
+def get_partition_info(part: Object) -> PartInfo:
+    """
+    Returns partition info from ``struct hd_struct`` or ``struct block_device``
+    depending on the kernel version.
+    """
+    if "block_device" in part.type_.type_name():
+        return get_partinfo_from_blkdev_struct(part)
+    else:
+        return get_partinfo_from_hd_struct(part)
+
+
 def print_partition_info(prog: Program) -> None:
     """
     Prints partition information
@@ -100,10 +111,7 @@ def print_partition_info(prog: Program) -> None:
             else:
                 part_is_blkdev = 0
                 table.header[-1] = "HD STRUCT"
-        if part_is_blkdev == 1:
-            info = get_partinfo_from_blkdev_struct(part)
-        else:
-            info = get_partinfo_from_hd_struct(part)
+        info = get_partition_info(part)
         table.row(*info._replace(obj=info.obj.value_()))
 
     table.write()

--- a/drgn_tools/scsi.py
+++ b/drgn_tools/scsi.py
@@ -13,6 +13,7 @@ from drgn import Program
 from drgn.helpers.linux.list import list_for_each_entry
 
 from drgn_tools.corelens import CorelensModule
+from drgn_tools.device import class_to_subsys
 from drgn_tools.table import print_table
 from drgn_tools.util import has_member
 
@@ -27,7 +28,8 @@ def for_each_scsi_host(prog: Program) -> Iterator[Object]:
         "knode_class"
     )
 
-    devices = prog["shost_class"].p.klist_devices.k_list.address_of_()
+    subsys_p = class_to_subsys(prog["shost_class"].address_of_())
+    devices = subsys_p.klist_devices.k_list.address_of_()
 
     if class_in_private:
         for device_private in list_for_each_entry(

--- a/drgn_tools/virtio.py
+++ b/drgn_tools/virtio.py
@@ -373,7 +373,7 @@ def get_module_name(dev_obj: Object) -> t.Optional[str]:
     :param dev_obj: Object of type ``struct device *``
     :returns: module name, or None
     """
-    mod = address_to_module(dev_obj.driver)
+    mod = address_to_module(dev_obj.prog_, dev_obj.driver)
     if mod:
         return KernelModule(mod).name
     return None

--- a/drgn_tools/virtio.py
+++ b/drgn_tools/virtio.py
@@ -14,6 +14,7 @@ from drgn import Program
 from drgn.helpers.linux.list import list_for_each_entry
 
 from drgn_tools.corelens import CorelensModule
+from drgn_tools.device import bus_to_subsys
 from drgn_tools.logging import get_logger
 from drgn_tools.module import address_to_module
 from drgn_tools.module import KernelModule
@@ -169,8 +170,9 @@ def get_virtio_devices(virtio_drv: Object) -> t.List[Object]:
     :param virtio_drv: Object of ``struct virtio_driver``
     :returns: List of all virtio device's ``struct device *``
     """
-    # virtio_driver -> device_driver -> bus_type -> subsys_private
-    subsys_p = virtio_drv.driver.bus.p
+    # virtio_driver -> device_driver -> bus_type
+    bus_type = virtio_drv.driver.bus
+    subsys_p = bus_to_subsys(bus_type)
 
     # Get the "struct list_head *" of the list of all devices for this
     # subsys_private.

--- a/drgn_tools/workqueue.py
+++ b/drgn_tools/workqueue.py
@@ -451,11 +451,18 @@ def show_pwq(pwq: Object) -> None:
 
     print(f"pwq: ({pwq.type_.type_name()})0x{pwq.value_():x}")
     print("pool id:", pwq.pool.id.value_())
+    # v6.9: a045a272d887 ("workqueue: Move pwq->max_active to wq->max_active")
+    # Note that this commit appears to have been backported into stable trees,
+    # and then also reverted...
+    if hasattr(pwq, "max_active"):
+        max_active = pwq.max_active
+    else:
+        max_active = pwq.wq.max_active
     print(
         "active/max_active ",
         pwq.nr_active.value_(),
         "/",
-        pwq.max_active.value_(),
+        max_active.value_(),
     )
     print(f"refcnt: {pwq.refcnt.value_()} Mayday: {mayday}")
 

--- a/testing/litevm/rpm.py
+++ b/testing/litevm/rpm.py
@@ -101,7 +101,7 @@ class TestKernel:
     def __init__(
         self,
         ol_ver: int,
-        uek_ver: int,
+        uek_ver: Union[int, str],
         arch: str,
         pkgs: List[str],
         cache_dir: Optional[Path] = None,
@@ -254,21 +254,21 @@ TEST_KERNELS = [
     # We also apparently need to add "-modules-core" RPMs, because there weren't
     # enough kernel RPMs yet.
     # Tests currently fail on UEK-next. Uncomment this to enable the tests:
-    # TestKernel(
-    #     9,
-    #     "next",
-    #     "x86_64",
-    #     [
-    #         "kernel-ueknext-core",
-    #         "kernel-ueknext-modules",
-    #         "kernel-ueknext-modules-core",
-    #     ],
-    #     yum_fmt=(
-    #         "https://yum.oracle.com/repo/OracleLinux/OL{ol_ver}/"
-    #         "developer/UEK{uek_ver}/{arch}/"
-    #     ),
-    #     pkgbase="kernel-ueknext",
-    # ),
+    TestKernel(
+        9,
+        "next",
+        "x86_64",
+        [
+            "kernel-ueknext-core",
+            "kernel-ueknext-modules",
+            "kernel-ueknext-modules-core",
+        ],
+        yum_fmt=(
+            "https://yum.oracle.com/repo/OracleLinux/OL{ol_ver}/"
+            "developer/UEK{uek_ver}/{arch}/"
+        ),
+        pkgbase="kernel-ueknext",
+    ),
     # UEK7 switches from a single "kernel-uek" to "-core" and "-modules".
     # The "kernel-uek" package still exists as a placeholder.
     TestKernel(9, 7, "x86_64", ["kernel-uek-core", "kernel-uek-modules"]),

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,7 +1,8 @@
-# Copyright (c) 2023, Oracle and/or its affiliates.
+# Copyright (c) 2024, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 import pytest
 
+from drgn_tools.module import address_to_module
 from drgn_tools.module import KernelModule
 from drgn_tools.module import module_exports
 
@@ -31,11 +32,20 @@ def test_list_modules(prog):
     assert len(mods) > 1
 
 
+def test_address_to_module(prog, common_mod):
+    for addr, size in common_mod.address_regions():
+        if size:
+            break
+    else:
+        pytest.fail("Common module has no address regions")
+
+    mod = address_to_module(prog, addr)
+    assert mod == common_mod.obj
+
+
 def test_module_memory(prog, common_mod):
     # smoke test
-    common_mod.address_region()
-    common_mod.init_region()
-    common_mod.percpu_region()
+    common_mod.address_regions()
 
 
 def test_module_build_id(prog, common_mod):

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -1,7 +1,49 @@
 # Copyright (c) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+from pathlib import Path
+
+import pytest
+from drgn.helpers.linux import for_each_partition
+
 from drgn_tools import partition
 
 
 def test_partitioninfo(prog):
     partition.print_partition_info(prog)
+
+
+@pytest.mark.skip_vmcore("*")
+def test_block_helpers(prog):
+    partitions_sysfs = set()
+    partitions_drgn = set()
+
+    def sysfs_int(p: Path, s: str, default: int = 0) -> int:
+        n = p / s
+        if not n.exists():
+            return default
+        return int(n.open().read().strip())
+
+    path = Path("/sys/class/block")
+    for block_dev_dir in path.iterdir():
+        size = sysfs_int(block_dev_dir, "size")
+        ro = bool(sysfs_int(block_dev_dir, "ro"))
+        start = sysfs_int(block_dev_dir, "start")
+        dev = (block_dev_dir / "dev").open().read().strip()
+        maj, min = map(int, dev.split(":"))
+        name = block_dev_dir.name
+        partitions_sysfs.add((name, size, ro, start, maj, min))
+
+    for part in for_each_partition(prog):
+        info = partition.get_partition_info(part)
+        partitions_drgn.add(
+            (
+                info.name,
+                info.nr_sects,
+                info.ro,
+                info.start_sect,
+                info.major,
+                info.minor,
+            )
+        )
+
+    assert partitions_sysfs == partitions_drgn

--- a/tests/test_smp.py
+++ b/tests/test_smp.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+import pytest
 from drgn.helpers.linux.cpumask import for_each_possible_cpu
 
 from drgn_tools import smp
@@ -15,5 +16,6 @@ def test_is_call_single_queue_empty(prog):
         print(smp.is_call_single_queue_empty(prog, cpu))
 
 
+@pytest.mark.skip_live  # flaky on live systems
 def test_dump_smp_ipi_state(prog):
     smp.dump_smp_ipi_state(prog)

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,5 +1,6 @@
-# Copyright (c) 2023, Oracle and/or its affiliates.
+# Copyright (c) 2024, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+import pytest
 from drgn.helpers.linux.pid import find_task
 from drgn.helpers.linux.pid import for_each_task
 
@@ -19,7 +20,13 @@ def test_user_kernel_threads(prog):
     assert task.is_user(init)
     assert task.is_group_leader(init)
 
-    kworker = next(for_each_worker(prog)).task
+    for worker in for_each_worker(prog):
+        if worker.task:
+            kworker = worker.task
+            break
+    else:
+        pytest.fail("no kworker available to test kthread helper")
+
     assert task.is_kthread(kworker)
     assert not task.is_user(kworker)
     assert task.is_group_leader(kworker)


### PR DESCRIPTION
This pull request begins running the Github CI tests against UEK-next, which is currently at 6.11. It includes a whole crop of fixes to helpers that allow the tests to pass. This is the first version of UEK-next that I'm actually doing this for, so it includes a lot of changes from UEK7 era up till the present.

These fixes are are necessary, but almost certainly incomplete. The Github CI tests are very small QEMU VMs, and I did manually verify that the tests pass against my laptop as well. There are plenty of subsystems not exercised by my laptop or the limited VM in the CI tests.

I'm breaking these changes down into a few categories for which I believe subject matter experts should review. If you're tagged here, please take a look at the subset of changes mentioned (note the Git SHAs may not be correct, as I may need to amend things to add bug references).

```
# SMP, workqueue: @imran-kn 
648a271 smp: skip test on live systems
8ded078 workqueue: handle changes in 6.9

# Virtual Filesystem / mounts: @gtmoth 
2d3ffc8 mounts: include superblock sub-type
0cf7aeb fsnotify: handle changes in 6.10
7bf4632 dentry: mark dentry_path_any_mount for removal

# Block IO: @biger410
32d3d64 partition: add tests for partition info
faa81ff partition: use block fixes for 6.10
9c5f640 block: fixes for v6.10
0f893d0 nvme: fixes for Linux 6.11

# Memory management: @jianfenw 
ef72437 numastat: Add missing stats from newer kernels
2e5bc1f task: support computing rss_stat for v6.2+

# Internals & tiny, obviously correct changes: @brenns10 
99bf206 bt: eliminate TODO for DWARF opcode exceptions
ea84304 module: remove compatibility with drgn < 0.0.21
a78f4b0 testing: litevm: enable testing on uek-next
2bb9b08 net: use task_cpu() helper

# Scheduling & generic kernel: @imran-kn or @biger410 
c86272c Fix for_each_task_in_group() for Linux 6.7+
18081d1 tests: task: fix failure on v6.9
c0dd25e module: support v6.4+ & efficient address lookup

# Generic driver APIs: @biger410 as a reviewer of last resort
afdf8d4 device: add helpers to get subsys_private
```