### PR TITLE
corelens: add support for multiple kmods in skip_unless_have_kmods

### DIFF
--- a/drgn_tools/dm.py
+++ b/drgn_tools/dm.py
@@ -318,7 +318,7 @@ class Dm(CorelensModule):
     """Display info about device mapper devices"""
 
     name = "dm"
-    skip_unless_have_kmod = "dm_mod"
+    skip_unless_have_kmods = ["dm_mod"]
 
     def run(self, prog: Program, args: argparse.Namespace) -> None:
         show_dm(prog)

--- a/drgn_tools/ext4_dirlock.py
+++ b/drgn_tools/ext4_dirlock.py
@@ -190,7 +190,7 @@ class Ext4DirLock(CorelensModule):
     """Scan processes hung by ext4 directory inode lock"""
 
     name = "ext4_dirlock_scan"
-    skip_unless_have_kmod = "ext4"
+    skip_unless_have_kmods = ["ext4"]
 
     def add_args(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(

--- a/drgn_tools/nfs_tools.py
+++ b/drgn_tools/nfs_tools.py
@@ -912,7 +912,7 @@ class NfsShow(CorelensModule):
     name = "nfsshow"
 
     # there's no point in running unless the nfs module is loaded
-    skip_unless_have_kmod = "nfs"
+    skip_unless_have_kmods = ["nfs"]
 
     # we need sunrpc, and all nfs related debuginfo loaded
     debuginfo_kmods = ["sunrpc", "nfs", "nfs*"]

--- a/drgn_tools/rds.py
+++ b/drgn_tools/rds.py
@@ -1540,7 +1540,7 @@ class Rds(CorelensModule):
     """Print info about RDS devices, sockets, connections, and stats"""
 
     name = "rds"
-    skip_unless_have_kmod = "rds"
+    skip_unless_have_kmods = ["rds"]
 
     # We access information from the following modules #
     debuginfo_kmods = ["mlx5_core", "mlx4_core", "mlx5_ib", "mlx4_ib"]


### PR DESCRIPTION
skip_unless_have_kmods can now take a list of modules as strings. Skip if any of the modules in the list are not present.