### PR TITLE
[1.x] inflightIO: fix crash due to missing member

### DIFF
--- a/drgn_tools/block.py
+++ b/drgn_tools/block.py
@@ -590,7 +590,12 @@ def get_inflight_io_nr(prog: drgn.Program, disk: Object) -> int:
         # hwq.tags were shared across different disks from same hba host.
         if (hwq.flags & BLK_MQ_F_TAG_SHARED) != 0:
             if (hwq.flags & BLK_MQ_F_TAG_HCTX_SHARED) != 0:
-                nr += hwq.queue.nr_active_requests_shared_tags.counter
+                # starting commit 079a2e3e8625, "nr_active_requests_shared_sbitmap"
+                # was renamed to "nr_active_requests_shared_tags".
+                if has_member(hwq.queue, "nr_active_requests_shared_tags"):
+                    nr += hwq.queue.nr_active_requests_shared_tags.counter
+                else:
+                    nr += hwq.queue.nr_active_requests_shared_sbitmap.counter
             else:
                 nr += hwq.nr_active.counter
         else:


### PR DESCRIPTION
commit 079a2e3e8625("blk-mq: Change shared sbitmap naming to shared tags") renamed "nr_active_requests_shared_sbitmap" to "nr_active_requests_shared_tags".

Orabug: 37394100