### PR TITLE
helper and corelens module to show unsubmitted pending works.

### DIFF
--- a/drgn_tools/workqueue.py
+++ b/drgn_tools/workqueue.py
@@ -684,13 +684,13 @@ class OfflinedDelayedWorksModule(CorelensModule):
     """
     Show delayed works from offlined CPUs.
     Delayed works (with non zero delay), rely on timer-wheel timers for
-    their submission. If these timers don't fire the work does not get
+    their submission. If these timers don't fire, the work does not get
     submitted. So delayed works submitted to an offlined CPU, don't get
     executed even after specified delay because timer-wheel timers on
     offlined CPUs don't get fired in first place.
 
     This corelens module list delayed works on offlined CPUs, so that
-    one can know if a delayed work was left unexececuted, due to the fact
+    one can know if a delayed work was left unexecuted, due to the fact
     that it was submitted on an offlined CPU.
     """
 

--- a/tests/test_workqueue.py
+++ b/tests/test_workqueue.py
@@ -105,3 +105,9 @@ def test_for_each_pending_work_of_pwq(prog: drgn.Program) -> None:
 
 def test_show_all_workqueues(prog: drgn.Program) -> None:
     wq.show_all_workqueues(prog)
+
+
+def test_show_unexpired_delayed_works(
+    prog: drgn.Program,
+) -> None:
+    wq.show_unexpired_delayed_works(prog)


### PR DESCRIPTION
Add helper and corelens module to show unsubmitted pending works.

dealyed_work(s) get their pending bit set but are actually submitted to a workqueue,
upon expiration of corresponding timer(s).
Recently we have found some cases where a delayed work submitted to an already
offlined CPU was never getting executed, because underlying timers were not
 firing in first place. Since the pending bit was set, this gave a notion that
 work item was lost to workqueue subsystem (which was not the case here.)
    
  Add an helper and a corelens module to dump delayed_work(s) whose timer has
  not yet expired. This is off interest for offline CPUs mainly, because ideally
  we should not see any delayed_work timer lying on an offlined CPU. So by default
  the helper and corelens module dump this info for offlined CPUs only