### PR TITLE
Fixes for CI failures

### DIFF
--- a/drgn_tools/kernfs_memcg.py
+++ b/drgn_tools/kernfs_memcg.py
@@ -41,7 +41,12 @@ def decode_css_flags(css: Object) -> str:
 
     :param css: ``struct cgroup_subsys_state *``
     """
-    CSS_DYING = css.prog_["CSS_DYING"]
+    # We only need the type of the enum containing the cgroup subsystem state
+    # constants. Unfortunately the enum is anonymous so we need to access the
+    # type via one of the enum members. CSS_ONLINE is present since
+    # a31f2d3ff7fe2 ("cgroup: introduce CSS_ONLINE flag and on/offline_css()
+    # helpers") in Linux 3.8, which is sufficient for our needs.
+    CSS_ONLINE = css.prog_.constant("CSS_ONLINE")
     flags = css.flags.value_()
     if not flags:
         # There is no dedicated flag value to indicate a zombie cgroup.
@@ -50,7 +55,7 @@ def decode_css_flags(css: Object) -> str:
         # of being pinned by some other object
         return "ZOMBIE"
 
-    return decode_enum_type_flags(flags, CSS_DYING.type_, False)
+    return decode_enum_type_flags(flags, CSS_ONLINE.type_, False)
 
 
 def for_each_kernfs_node(prog: Program) -> Iterator[Object]:

--- a/drgn_tools/kernfs_memcg.py
+++ b/drgn_tools/kernfs_memcg.py
@@ -185,15 +185,19 @@ def get_num_mem_cgroups(prog: Program) -> None:
 # that have memcg ref but if max_pages is specified
 # then we bail out after getting those many pages
 # or after scanning all pages , whichever happens first.
-def dump_page_cache_pages_pinning_cgroups(prog: Program, max_pages: int = 0):
+def dump_page_cache_pages_pinning_cgroups(
+    prog: Program, max_pages: int = 0, max_scan: int = 0
+):
     """
     Dump page-cache pages that have reference to a mem-cgroup.
-    The ouput also contains information such as the cgroup that is pinned, its flags
-    (to indicate current state of cgroup) and file cached by this page.
 
-    :params: max_pages: specify how many pages to find. By default first 10000 such
-    pages are listed. Use 0 to list all such pages.
+    The ouput also contains information such as the cgroup that is pinned, its
+    flags (to indicate current state of cgroup) and file cached by this page.
 
+    :param max_pages: specify how many pages to find. Use 0 (the default) to
+      list all such pages.
+    :param max_scan: how many pages to scan, regardless of whether any such
+      pages are found. Use 0 (the default) to scan all pages.
     """
     mem_cgroup_root = prog["cgroup_subsys"][_MEMORY_CGRP_ID].root
     total_count = 0
@@ -201,6 +205,8 @@ def dump_page_cache_pages_pinning_cgroups(prog: Program, max_pages: int = 0):
     fault_count = 0
     for page in for_each_page(prog):
         total_count = total_count + 1
+        if max_scan and total_count > max_scan:
+            break
         try:
             # Ignore slab pages
             if PageSlab(page):

--- a/drgn_tools/sysctl.py
+++ b/drgn_tools/sysctl.py
@@ -168,7 +168,6 @@ def get_data_entry(prog: Program, ct: Object) -> Any:
         "proc_dostring_coredump",
         "proc_do_uts_string",
         "devkmsg_sysctl_set_loglvl",
-        "proc_do_large_bitmap",
         "proc_watchdog_cpumask",
     }
     # for the cases where the data encoded is a text string

--- a/tests/test_kernfs_memcg.py
+++ b/tests/test_kernfs_memcg.py
@@ -6,7 +6,7 @@ from drgn_tools import kernfs_memcg as kernfs_memcg
 
 
 def test_dump_page_cache_pages_pinning_cgroups(prog: drgn.Program) -> None:
-    kernfs_memcg.dump_page_cache_pages_pinning_cgroups(prog, 10)
+    kernfs_memcg.dump_page_cache_pages_pinning_cgroups(prog, 10, 1000000)
 
 
 def test_dump_memcgroup_hierarchy(prog: drgn.Program) -> None:


### PR DESCRIPTION
Two fixes to recent changes - one in the kernfs_memcg code, and one in the sysctl code. Both of these are only present in the `main` branch so no backport is required. Since they're fixes to such recent code, I haven't created a bug for them.