### PR TITLE
Including corelens & drgn versions in reports

### DIFF
--- a/buildrpm/python-drgn-tools.spec
+++ b/buildrpm/python-drgn-tools.spec
@@ -82,7 +82,7 @@ Requires:       python3.12-drgn >= %{drgn_min}, python3.12-drgn < %{drgn_max}
 
 %prep
 %autosetup -n drgn-tools-%{version}
-echo '__version__ = "%{version}"' > drgn_tools/_version.py
+echo '__version__ = "%{version}+%{release}"' > drgn_tools/_version.py
 
 %build
 %py3_build

--- a/drgn_tools/corelens.py
+++ b/drgn_tools/corelens.py
@@ -27,7 +27,9 @@ from typing import Tuple
 
 from drgn import Program
 from drgn import ProgramFlags
+from drgn.cli import version_header as drgn_version_header
 
+from drgn_tools._version import __version__
 from drgn_tools.debuginfo import CtfCompatibility
 from drgn_tools.debuginfo import find_debuginfo
 from drgn_tools.debuginfo import KernelVersion
@@ -600,6 +602,17 @@ def _print_module_listing() -> None:
             print(" " * (maxlen), note)
 
 
+def _version_string() -> str:
+    try:
+        from drgn.helpers.linux.ctf import load_ctf  # noqa
+
+        ctf_str = "with CTF"
+    except ModuleNotFoundError:
+        ctf_str = "without CTF"
+
+    return f"drgn-tools {__version__}, {drgn_version_header()}, {ctf_str}"
+
+
 def main() -> None:
     corelens_begin_time = time.time()
     parser = argparse.ArgumentParser(
@@ -629,6 +642,12 @@ def main() -> None:
         "-L",
         action="store_true",
         help="list corelens module names",
+    )
+    parser.add_argument(
+        "--version",
+        "-V",
+        action="store_true",
+        help="print the version of corelens",
     )
     parser.add_argument(
         "--debuginfo",
@@ -663,6 +682,9 @@ def main() -> None:
     args = parser.parse_args(split_args[0])
     if args.list:
         _print_module_listing()
+        sys.exit(0)
+    elif args.version:
+        print(_version_string())
         sys.exit(0)
 
     # Load corelens modules before initializing prog, so that the argument
@@ -744,6 +766,7 @@ def main() -> None:
         def info_msg(*args, **kwargs):
             pass
 
+    info_msg(_version_string())
     kind = "CTF" if ctf else "DWARF"
     info_msg(f"Loaded {kind} debuginfo in in {load_time:.03f}s")
 


### PR DESCRIPTION
There are two related issues fixed here:

1. The useful messages that give the debuginfo type and the runtime are only printed in "report mode", which is when `-o` is used. LKCE does not use report mode, so its reports don't have that information, which is a shame. To fix this, add a "corelens" section to the stdout output whenever more than one module is run. This ensures that the common case of `corelens VMCORE -M one_module` doesn't get a bunch of extra output that won't be useful for most people.
2. Some useful info was missing in this output - the drgn-tools & drgn versions. So add that in.

To make the versions even more useful, I've updated the packaging scripts so that the version string reported by corelens is (nearly) identical to the RPM version, if it was installed via the RPM. That can help differentiate between supported & unsupported installations (e.g. running from git or from source).

I'm avoiding adding options like `--verbose` or `--quiet` here because the logic is already complicated enough. I'd like to avoid custom flags to add or remove specific kinds of output. Hopefully each of the above modes is intuitive enough that people don't really need to think about it - the output just makes sense.

To test this, I've verified that the output for each of the three possible cases (described in the code) and I've also built the RPMs on OL9 and installed. Here's what it looks like for a silly (small) output on my laptop where we're running multiple modules to stdout:
```
$ corelens /proc/kcore -M ls / -c -M ls /home/stepbren -c
warning: Running corelens against a live system.
         Data may be inconsistent, or corelens may crash.

====== MODULE ls ======
/:
        23 positive, 339 negative dentries

====== MODULE ls ======
/home/stepbren:
        115 positive, 375 negative dentries

====== corelens ======
drgn-tools 2.0.1+1.el9, drgn 0.0.30 (using Python 3.9.21, elfutils 0.191, with libkdumpfile), with CTF
Loaded CTF debuginfo in in 0.790s
Running module ls... completed in 0.002s
Running module ls... completed in 0.005s
corelens total runtime: 0.807s
```

Compared to the below, when it's just one module:
```
$ corelens /proc/kcore -M ls / -c
warning: Running corelens against a live system.
         Data may be inconsistent, or corelens may crash.
/:
        23 positive, 339 negative dentries
```

The version "2.0.1" is fake (we haven't released it yet), but it illustrates the idea. The version & release are separated by the `+` sign due to limitations in what Python allows for version names.

Orabug: 37503503
