### PR TITLE
Add support for drgn 0.0.32

### DIFF
--- a/.github/workflows/litevm.yml
+++ b/.github/workflows/litevm.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Build and install drgn with CTF support
         run: |
           cd ..
-          git clone https://github.com/brenns10/drgn -b ctf_0.0.31
+          git clone https://github.com/brenns10/drgn -b ctf_0.0.32
           cd drgn
           ../drgn-tools/venv/bin/pip install .
       - name: Run tests

--- a/buildrpm/python-drgn-tools.spec
+++ b/buildrpm/python-drgn-tools.spec
@@ -59,7 +59,7 @@ a running kernel image (via /proc/kcore).}
 # The drgn dependency can be fulfilled by drgn with, or without, CTF support.
 # However, drgn-tools is tied to specific drgn releases.
 %global drgn_min 0.0.25
-%global drgn_max 0.0.32
+%global drgn_max 0.0.33
 
 %package -n     drgn-tools
 Summary:        %{summary}

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
     description="drgn helper script repository",
     long_description=long_description,
     install_requires=[
-        "drgn>=0.0.25,<0.0.32",
+        "drgn>=0.0.25,<0.0.33",
     ],
     url="https://github.com/oracle-samples/drgn-tools",
     author="Oracle Linux Sustaining Engineering Team",


### PR DESCRIPTION
The changes are small so we'll do basic testing and then add it to the allowable drgn-tools versions. We need this in order to release drgn because otherwise, 0.0.32 would break existing drgn-tools installs.