### PR TITLE
[stable] rds: fix crash on NULL task

### DIFF
--- a/drgn_tools/rds.py
+++ b/drgn_tools/rds.py
@@ -21,6 +21,7 @@ from typing import Union
 import drgn
 from drgn import cast
 from drgn import container_of
+from drgn import FaultError
 from drgn import Object
 from drgn import PlatformFlags
 from drgn import Program
@@ -1090,12 +1091,12 @@ def rds_sock_info(
             pid: Any = int(sock.rs_pid.value_())
             task = find_task(prog, pid)
             comm: Any = "".join(re.findall('"([^"]*)"', str(task.comm)))
-        except AttributeError:
+        except (AttributeError, FaultError):
             pid = "N/A"
             comm = "N/A"
         try:
             cong: Any = int(sock.rs_congested)
-        except AttributeError:
+        except (AttributeError, FaultError):
             cong = "N/A"
         send_buf = rds_sk_sndbuf(sock)
         recv_buf = rds_sk_rcvbuf(sock)


### PR DESCRIPTION
It seems that sometimes the task could be NULL, and in this case we should allow the module to continue executing.

Orabug: 38225232