### PR TITLE
New corelens module: pstack

### DIFF
--- a/drgn_tools/pstack.py
+++ b/drgn_tools/pstack.py
@@ -1,0 +1,503 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+"""
+Tools for creating stack traces of userspace tasks, from the kernel
+
+This script contains tools that enable creating stack traces for userspace
+tasks, when debugging a kernel program. This requires having access to the
+userspace pages, which is not common for core dumps (see makedumpfile's -d
+option), however it is available for /proc/kcore and /proc/vmcore. The script
+contains two approaches:
+
+1. By directly creating a Program to represent a process, which reads memory via
+   the kernel Program. This allows directly printing stack traces. This approach
+   works well with /proc/kcore, but in the kexec/kdump environment it may
+   require too much memory, as well as access to the full root filesystem.
+2. By dumping userspace stack memory and some metadata. Later, a second call can
+   read this information and actually create the stack trace. This approach
+   works better in a kexec environment, because the root filesystem is not
+   required, and userspace debuginfo is not consulted.
+
+This script is only tested on x86_64, and it's especially suited for Fedora and
+its derivatives, due to their inclusion of ".eh_frame" on runtime binaries, as
+well as ".gnu_debugdata" sections for address to symbol resolution.
+"""
+import argparse
+import base64
+import fnmatch
+import gzip
+import json
+import logging
+import os
+import struct
+import sys
+from bisect import bisect_left
+from pathlib import Path
+from typing import Any
+from typing import BinaryIO
+from typing import Dict
+from typing import Iterator
+from typing import List
+from typing import Tuple
+
+import drgn
+from drgn import FaultError
+from drgn import Object
+from drgn import Program
+from drgn import sizeof
+from drgn.helpers.linux import access_remote_vm
+from drgn.helpers.linux import cpu_curr
+from drgn.helpers.linux import d_path
+from drgn.helpers.linux import find_task
+from drgn.helpers.linux import for_each_online_cpu
+from drgn.helpers.linux import for_each_task
+from drgn.helpers.linux import for_each_vma
+from drgn.helpers.linux import task_state_to_char
+from drgn.helpers.linux import vma_find
+
+from drgn_tools.corelens import CorelensModule
+from drgn_tools.task import for_each_task_in_group
+
+
+log = logging.getLogger("drgn.pstack")
+
+
+def get_pt_regs(task: Object) -> Object:
+    """
+    Create a ``struct pt_regs`` for the given task struct
+
+    :param task: the ``struct task_struct *`` of this task
+    :returns: a ``struct pt_regs`` value object
+    """
+    prog = task.prog_
+    # The pt_regs is dumped at the top of the stack. The stack size may vary,
+    # but it gets a guard page on top, and there's sometimes padding. See
+    # TOP_OF_STACK_PADDING in arch/x86/include/asm/thread_info.h -- for x86_64,
+    # if FRED is enabled, then there is 16 bytes of padding, otherwise 0.
+    # an offset of 16 bytes for 64-bit.
+    try:
+        prog.symbol("fred_rsp0")
+        padding = 16
+    except LookupError:
+        padding = 0
+    regs_addr = (
+        task.stack_vm_area.addr.value_()
+        + task.stack_vm_area.size.value_()
+        - sizeof(prog.type("struct pt_regs"))
+        - prog["PAGE_SIZE"]
+        - padding
+    )
+    return Object(prog, "struct pt_regs", address=regs_addr)
+
+
+def make_fake_pt_regs(up: Program, data: bytes) -> Object:
+    """
+    Create a fake ``struct pt_regs`` to convince drgn to unwind a thread
+
+    Drgn's unwinder will accept any object that looks like a ``struct pt_regs``
+    (a correctly-named struct of the correct size) and use it as the initial
+    registers for a stack unwind. This function can take the bytes of a real
+    pt_regs object, and a Program, and return an object associated with that
+    program which drgn will unwind.
+
+    :param up: a user program, like the one returned by ``get_user_prog()``
+    :param data: the bytes of a ``struct pt_regs``, like that returned by
+      ``get_pt_regs()``
+    """
+    # Luckily, all drgn cares about for x86_64 pt_regs is that it is a structure
+    # with the right size. Rather than creating a matching struct pt_regs
+    # definition, we can just create a dummy one of the correct size:
+    #     struct pt_regs {};
+    # Drgn will happily use that (not questioning why an empty struct has that
+    # size), and we can save ourselves the trouble of creating a convincing
+    # replica of the real struct.
+    fake_pt_regs_type = up.struct_type(
+        tag="pt_regs", size=len(data), members=[]
+    )
+    return Object.from_bytes_(up, fake_pt_regs_type, data)
+
+
+def get_tasks(prog: Program, args: argparse.Namespace) -> Iterator[Object]:
+    """Return an iterable of tasks according to the dump arguments"""
+    if args.pid:
+        for pid in args.pid:
+            yield find_task(prog, pid)
+    elif args.online:
+        for cpu in for_each_online_cpu(prog):
+            yield cpu_curr(prog, cpu)
+    else:
+        if args.comm:
+            args.comm = args.comm.encode("utf-8")
+        for task in for_each_task(prog):
+            if task.tgid != task.pid:
+                continue  # only handle group leaders
+            if args.state and task_state_to_char(task) != args.state:
+                continue
+            if args.comm and not fnmatch.fnmatch(
+                task.comm.string_(), args.comm
+            ):
+                continue
+            yield task
+
+
+def add_task_args(parser: argparse.ArgumentParser) -> None:
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--online",
+        "-o",
+        action="store_true",
+        help="dump stacks for all on-cpu tasks (not supported for live kernels)",
+    )
+    group.add_argument(
+        "--all",
+        "-a",
+        action="store_true",
+        help="dump stacks for all PIDs (not recommended)",
+    )
+    group.add_argument(
+        "--state",
+        "-s",
+        help="dump stacks for all tasks in given state (ps(1) 1-letter code)",
+    )
+    group.add_argument(
+        "--comm",
+        "-c",
+        help="dump stacks for all tasks whose command matches this pattern (glob)",
+    )
+    group.add_argument(
+        "--pid",
+        "-p",
+        action="append",
+        type=int,
+        help="dump stack for specific PIDs (may be specified multiple times)",
+    )
+
+
+def write_pages(outfile: BinaryIO, task: Object, start: int, end: int) -> None:
+    """Write pages from start to end, skipping ones which are swapped out."""
+    prog = task.prog_
+    pgsize = prog["PAGE_SIZE"].value_()
+    for pgaddr in range(start, end, pgsize):
+        try:
+            data = access_remote_vm(task.mm, pgaddr, pgsize)
+        except FaultError:
+            continue
+        outfile.write(struct.pack("=Q", pgaddr))
+        outfile.write(data)
+
+
+def task_metadata(prog: Program, task: Object) -> Dict[str, Any]:
+    """Return JSON metadata about a task, for later use."""
+    VM_EXEC = 0x4
+    load_addrs = {}
+    file_vm_end: Dict[str, int] = {}
+    for vma in for_each_vma(task.mm):
+        if not vma.vm_file:
+            continue
+        path = os.fsdecode(d_path(vma.vm_file.f_path))
+        file_vm_end[path] = max(
+            vma.vm_end.value_(),
+            file_vm_end.get(path, 0),
+        )
+        if vma.vm_flags & VM_EXEC and vma.vm_file:
+            file_start = (
+                vma.vm_start - vma.vm_pgoff * task.mm.prog_["PAGE_SIZE"]
+            ).value_()
+            inode = vma.vm_file.f_inode.i_ino.value_()
+            load_addrs[path] = [file_start, vma.vm_end.value_(), inode]
+
+    # use the largest vm_end we find for the end of the address range
+    for path in load_addrs:
+        load_addrs[path][1] = file_vm_end[path]
+    return {
+        "pid": task.pid.value_(),
+        "page_size": prog["PAGE_SIZE"].value_(),
+        "comm": task.comm.string_().decode("utf-8", errors="replace"),
+        "mm": load_addrs,
+        "threads": [],
+    }
+
+
+def dump(prog: Program) -> None:
+    parser = argparse.ArgumentParser(description="dump stacks")
+    parser.add_argument(
+        "directory",
+        help="store stack dumps in the given directory by PID",
+    )
+    add_task_args(parser)
+    args = parser.parse_args(sys.argv[2:])
+
+    dir_ = Path(args.directory)
+    dir_.mkdir(exist_ok=True)
+    page_mask = ~(prog["PAGE_SIZE"] - 1)
+    for task in get_tasks(prog, args):
+        # Skip kthreads and zombies without memory
+        if not task.mm:
+            continue
+        metadata = task_metadata(prog, task)
+        with gzip.open(dir_ / f"{task.pid.value_()}.gz", "wb") as f:
+            for thread in for_each_task_in_group(task, include_self=True):
+                tid = thread.pid.value_()
+                tcomm = thread.comm.string_().decode("utf-8", errors="replace")
+                regs = get_pt_regs(thread)
+                try:
+                    kstack = str(prog.stack_trace(thread))
+                except ValueError:
+                    log.warning("skipped running TID %d ('%s')", tid, tcomm)
+                    continue
+                metadata["threads"].append(
+                    {
+                        "tid": tid,
+                        "comm": tcomm,
+                        "kstack": kstack,
+                        "regs": base64.b64encode(regs.to_bytes_()).decode(),
+                    },
+                )
+                # Three big assumptions here: (1) the stack grows down, (2)
+                # there is no stack switching going on, and (3) the stack is in
+                # its own VMA.  These are usually true, but not always.
+                vma = vma_find(task.mm, regs.sp)
+                if not vma:
+                    log.warning(
+                        "could not find VMA for SP (%x) in TID %d ('%s')",
+                        regs.sp.value_(),
+                        tid,
+                        tcomm,
+                    )
+                    continue
+                start = (regs.sp & page_mask).value_()
+                end = vma.vm_end.value_()
+                # mypy false positive:
+                # Argument 1 to "write_pages" has incompatible type "GzipFile"; expected "BinaryIO"  [arg-type]
+                write_pages(f, thread, start, end)  # type: ignore
+        with gzip.open(dir_ / f"{task.pid.value_()}-meta.json.gz", "wb") as f:
+            f.write(json.dumps(metadata).encode("utf-8"))
+
+
+def build_prog_from_dump(
+    data: List[Tuple[int, bytes]], metadata: Dict[str, Any]
+) -> Program:
+    prog = Program(drgn.host_platform)
+    page_size = metadata["page_size"]
+    data.sort()
+
+    def read_fn(_, count, offset, __):
+        # This may be a bit overkill given that the average single-threaded task
+        # only has a few stack pages to speak of. But I can't justify using a
+        # linear search when binary search will do better.
+        page = offset & ~(page_size - 1)
+        # bisect_left gained a "key" kwarg, but in Python 3.10, oh well...
+        index = bisect_left(data, (page, b""))
+        output = bytearray()
+        while len(output) < count:
+            if index >= len(data) or data[index][0] != page:
+                raise FaultError("memory not present", page)
+            pgoff = (offset + len(output)) & (page_size - 1)
+            pgend = min(page_size, pgoff + count - len(output))
+            output += data[index][1][pgoff:pgend]
+
+            # Move to the next page, which is hopefully present if we have more
+            # to read.
+            page += page_size
+            index += 1
+        return output
+
+    prog.add_memory_segment(0, 0xFFFFFFFFFFFFFFFF, read_fn, False)
+
+    pid = metadata["pid"]
+    for name, (start, end, ino) in metadata["mm"].items():
+        path = Path(name)
+        inode = None
+        try:
+            if path.exists():
+                inode = path.stat().st_ino
+            else:
+                log.warning("For PID %d, could not find file %s", pid, name)
+                continue
+        except OSError as e:
+            log.warning(
+                "For PID %d, could not access file %s (%r)", pid, name, e
+            )
+            continue
+        if inode is not None and inode != ino:
+            log.warning(
+                "For PID %d, file %s inode does not match, file may be updated",
+                pid,
+                name,
+            )
+        mod = prog.extra_module(name=name, create=True)
+        mod.address_range = (start, end)
+        mod.try_file(name, force=True)
+    return prog
+
+
+def print_user_stack_trace(regs: Object) -> None:
+    """
+    Prints the userspace stack trace for regs, with the module name included
+    for ecah frame. Including the module name is pretty important for userspace.
+    """
+    prog = regs.prog_
+    trace = prog.stack_trace(regs)
+    print("    ------ userspace ---------")
+    for frame, line in zip(trace, str(trace).split("\n")):
+        mod_text = ""
+        try:
+            mod = prog.module(frame.pc)
+            off = frame.pc - mod.address_range[0]
+            mod_text = f" (in {mod.name} +{off:x})"
+        except LookupError:
+            pass
+        print("    " + line.rstrip() + mod_text)
+
+
+def dump_print_process(f: Path) -> None:
+    """Print traces for a dumped process"""
+    PAGE_SIZE = 4096
+    with gzip.open(f, "rb") as fp:
+        meta = json.loads(fp.read().decode("utf-8"))
+
+    pid = meta["pid"]
+    data = []
+    with gzip.open(f.parent / f"{pid}.gz", "rb") as fp:
+        while True:
+            header = fp.read(8)
+            if not header:
+                break
+            addr = struct.unpack("=Q", header)[0]
+            data.append((addr, fp.read(PAGE_SIZE)))
+
+    prog = build_prog_from_dump(data, meta)
+    comm = meta["comm"]
+    print(f"[PID: {pid} COMM: {comm}]")
+    for i, t in enumerate(meta["threads"]):
+        tid = t["tid"]
+        tcomm = t["comm"]
+        print(f"  Thread {i} TID={tid} ('{tcomm}')")
+        print("    " + t["kstack"].replace("\n", "\n    "))
+        regs = make_fake_pt_regs(prog, base64.b64decode(t["regs"]))
+        print_user_stack_trace(regs)
+
+
+def dump_print(d: str):
+    parser = argparse.ArgumentParser(
+        description="print traces for dumped stacks"
+    )
+    parser.add_argument("directory", type=Path, help="output directory")
+    args = parser.parse_args(sys.argv[2:])
+    for f in args.directory.iterdir():
+        if not f.name.endswith("-meta.json.gz"):
+            continue
+        dump_print_process(f)
+        print()
+
+
+def build_prog_from_mm(mm: Object) -> Program:
+    """
+    Create a Program representing a userspace task in the kernel Program
+
+    :param mm: the ``struct mm_struct`` for the process
+    :returns: a Program which can be debugged like a userspace process
+    """
+    prog = mm.prog_
+    up = Program(prog.platform)
+
+    def read_fn(_, count, offset, __):
+        return access_remote_vm(mm, offset, count)
+
+    up.add_memory_segment(0, 0xFFFFFFFFFFFFFFFF, read_fn, False)
+
+    # Do one pass where we record the maximum extent of the mapping for each
+    # file, and we also detect each executable mapping, for which we prepare
+    # modules.
+    file_vm_end: Dict[str, int] = {}
+    VM_EXEC = 0x4
+    for vma in for_each_vma(mm):
+        if vma.vm_file:
+            path = os.fsdecode(d_path(vma.vm_file.f_path))
+            file_vm_end[path] = max(
+                vma.vm_end.value_(), file_vm_end.get(path, 0)
+            )
+        if vma.vm_flags & VM_EXEC and vma.vm_file:
+            try:
+                statbuf = os.stat(path)
+                if statbuf.st_ino != vma.vm_file.f_inode.i_ino.value_():
+                    log.warning(
+                        "file %s doesn't match the inode on-disk, it may"
+                        " have been updated",
+                        path,
+                    )
+            except OSError:
+                pass
+            file_start = (
+                vma.vm_start - vma.vm_pgoff * mm.prog_["PAGE_SIZE"]
+            ).value_()
+            mod = up.extra_module(path, create=True)
+            mod.address_range = (file_start, vma.vm_end.value_())
+
+    # Now set the address ranges based on the observed file end, then load the
+    # ELF files.
+    for mod in up.modules():
+        path = mod.name
+        mod.address_range = (mod.address_range[0], file_vm_end[path])
+        mod.try_file(path)
+
+    return up
+
+
+def pstack_print_process(task: Object) -> None:
+    comm = task.comm.string_().decode("utf-8", errors="replace")
+    print(f"[PID: {task.pid.value_()} COMM: {comm}]")
+    prog = task.prog_
+    if not task.mm:
+        print(str(prog.stack_trace(task)).replace("\n", "\n  "))
+        return
+
+    user_prog = build_prog_from_mm(task.mm)
+    for i, thread in enumerate(
+        for_each_task_in_group(task, include_self=True)
+    ):
+        tid = thread.pid.value_()
+        tcomm = thread.comm.string_().decode("utf-8", errors="replace")
+        print(f"  Thread {i} TID={tid} ('{tcomm}')")
+        print("    " + str(prog.stack_trace(thread)).replace("\n", "\n    "))
+        regs = get_pt_regs(task)
+        fake_regs = make_fake_pt_regs(user_prog, regs.to_bytes_())
+        print_user_stack_trace(fake_regs)
+
+
+def pstack(prog: Program) -> None:
+    parser = argparse.ArgumentParser(description="print stack traces")
+    add_task_args(parser)
+    args = parser.parse_args(sys.argv[2:])
+    for task in get_tasks(prog, args):
+        pstack_print_process(task)
+        print()
+
+
+class Pstack(CorelensModule):
+    """Select and print user + kernel stacks, if data is available"""
+
+    name = "pstack"
+
+    def add_args(self, parser: argparse.ArgumentParser) -> None:
+        add_task_args(parser)
+
+    def run(self, prog: Program, args: argparse.Namespace) -> None:
+        for task in get_tasks(prog, args):
+            pstack_print_process(task)
+            print()
+
+
+if __name__ == "__main__":
+    logging.basicConfig()
+    prog: Program
+    if len(sys.argv) <= 1 or sys.argv[1] not in ("dump", "print", "pstack"):
+        sys.exit(
+            f"usage: drgn [args...] {sys.argv} [dump | print | pstack] ..."
+        )
+    elif sys.argv[1] == "dump":
+        dump(prog)  # noqa
+    elif sys.argv[1] == "print":
+        dump_print(sys.argv[2])
+    elif sys.argv[1] == "pstack":
+        pstack(prog)  # noqa

--- a/drgn_tools/pstack.py
+++ b/drgn_tools/pstack.py
@@ -18,9 +18,9 @@ contains two approaches:
    works better in a kexec environment, because the root filesystem is not
    required, and userspace debuginfo is not consulted.
 
-This script is only tested on x86_64, and it's especially suited for Fedora and
-its derivatives, due to their inclusion of ".eh_frame" on runtime binaries, as
-well as ".gnu_debugdata" sections for address to symbol resolution.
+This script is tested on x86_64 and aarch64, and it's especially suited for
+Fedora and its derivatives, due to their inclusion of ".eh_frame" on runtime
+binaries, as well as ".gnu_debugdata" sections for address to symbol resolution.
 """
 import argparse
 import base64
@@ -41,10 +41,12 @@ from typing import List
 from typing import Tuple
 
 import drgn
+from drgn import Architecture
 from drgn import FaultError
 from drgn import Object
 from drgn import Program
 from drgn import sizeof
+from drgn import StackTrace
 from drgn.helpers.linux import access_remote_vm
 from drgn.helpers.linux import cpu_curr
 from drgn.helpers.linux import d_path
@@ -62,9 +64,18 @@ from drgn_tools.task import for_each_task_in_group
 log = logging.getLogger("drgn.pstack")
 
 
-def get_pt_regs(task: Object) -> Object:
+def task_saved_pt_regs(task: Object) -> Object:
     """
-    Create a ``struct pt_regs`` for the given task struct
+    Return the userspace registers for the given task struct
+
+    This returns the registers which were saved on entry to the kernel. For
+    vmcores generated via kexec and /proc/vmcore, all userspace tasks will have
+    registers stored on the stack, because every CPU should be interrupted and
+    halted. However, for vmcores which were created by a hypervisor, or for
+    live systems, userspace tasks may be directly executing, and any data stored
+    on the kernel stack is stale. Drgn does not provide an easy API to get this
+    info, but you can tell based on whether the stack pointer is a user or
+    kernel address.
 
     :param task: the ``struct task_struct *`` of this task
     :returns: a ``struct pt_regs`` value object
@@ -88,6 +99,64 @@ def get_pt_regs(task: Object) -> Object:
         - padding
     )
     return Object(prog, "struct pt_regs", address=regs_addr)
+
+
+def task_running_pt_regs(kstack: StackTrace) -> Object:
+    """
+    Create a ``struct pt_regs`` object from the top frame of a stack trace
+
+    This returns the registers for a task that is/was actively running. They
+    should be stored in the core dump metadata (e.g. PRSTATUS), and we can get
+    at them via drgn's stack trace object. Drgn's kernel Program won't be able
+    to unwind it anyway.
+
+    :param kstack: The kernel stack trace.
+    :returns: A ``struct pt_regs`` value object containing the user-space registers.
+    """
+    prog = kstack.prog
+    pt_regs = {}
+    tp = prog.type("struct pt_regs")
+    if prog.platform.arch == Architecture.X86_64:
+        rename = {
+            "rip": "ip",
+            "rbp": "bp",
+            "rax": "ax",
+            "rbx": "bx",
+            "rcx": "cx",
+            "rdx": "dx",
+            "rdi": "di",
+            "rsi": "si",
+            "rsp": "sp",
+            "rflags": "flags",
+        }
+        for name, value in kstack[0].registers().items():
+            if name in rename:
+                name = rename[name]
+            try:
+                tp.member(name)
+            except LookupError:
+                continue
+            pt_regs[name] = value
+    elif prog.platform.arch == Architecture.AARCH64:
+        pt_regs["regs"] = [0] * 31
+        pt_regs["pc"] = kstack[0].pc
+        for name, value in kstack[0].registers().items():
+            if name[0] == "x":
+                pt_regs["regs"][int(name[1:])] = value
+            elif name == "lr":  # an alias for x30
+                pt_regs["regs"][30] = value
+            else:
+                try:
+                    tp.member(name)
+                    pt_regs[name] = value
+                except LookupError:
+                    pass
+    else:
+        raise NotImplementedError(
+            f"Support for {prog.platform.arch} is not implemented"
+        )
+
+    return Object(prog, "struct pt_regs", value=pt_regs)
 
 
 def make_fake_pt_regs(up: Program, data: bytes) -> Object:
@@ -239,17 +308,26 @@ def dump(prog: Program) -> None:
             for thread in for_each_task_in_group(task, include_self=True):
                 tid = thread.pid.value_()
                 tcomm = thread.comm.string_().decode("utf-8", errors="replace")
-                regs = get_pt_regs(thread)
                 try:
-                    kstack = str(prog.stack_trace(thread))
+                    kstack = prog.stack_trace(thread)
                 except ValueError:
                     log.warning("skipped running TID %d ('%s')", tid, tcomm)
                     continue
+                if len(kstack) > 0 and (kstack[0].pc & (1 << 63)):
+                    # CPU was running in kernel mode, get the saved registers
+                    regs = task_saved_pt_regs(thread)
+                    kstack_str = str(kstack)
+                else:
+                    # CPU was in user mode. Drgn won't make be able to unwind
+                    # it, but we can take the top frame and get the original
+                    # registers for unwinding.
+                    regs = task_running_pt_regs(kstack)
+                    kstack_str = "<running in user mode>"
                 metadata["threads"].append(
                     {
                         "tid": tid,
                         "comm": tcomm,
-                        "kstack": kstack,
+                        "kstack": kstack_str,
                         "regs": base64.b64encode(regs.to_bytes_()).decode(),
                     },
                 )
@@ -334,7 +412,7 @@ def build_prog_from_dump(
 def print_user_stack_trace(regs: Object) -> None:
     """
     Prints the userspace stack trace for regs, with the module name included
-    for ecah frame. Including the module name is pretty important for userspace.
+    for each frame. Including the module name is pretty important for userspace.
     """
     prog = regs.prog_
     trace = prog.stack_trace(regs)
@@ -344,7 +422,7 @@ def print_user_stack_trace(regs: Object) -> None:
         try:
             mod = prog.module(frame.pc)
             off = frame.pc - mod.address_range[0]
-            mod_text = f" (in {mod.name} +{off:x})"
+            mod_text = f" (in {mod.name} +0x{off:x})"
         except LookupError:
             pass
         print("    " + line.rstrip() + mod_text)
@@ -449,7 +527,7 @@ def pstack_print_process(task: Object) -> None:
     print(f"[PID: {task.pid.value_()} COMM: {comm}]")
     prog = task.prog_
     if not task.mm:
-        print(str(prog.stack_trace(task)).replace("\n", "\n  "))
+        print("  " + str(prog.stack_trace(task)).replace("\n", "\n  "))
         return
 
     user_prog = build_prog_from_mm(task.mm)
@@ -459,8 +537,17 @@ def pstack_print_process(task: Object) -> None:
         tid = thread.pid.value_()
         tcomm = thread.comm.string_().decode("utf-8", errors="replace")
         print(f"  Thread {i} TID={tid} ('{tcomm}')")
-        print("    " + str(prog.stack_trace(thread)).replace("\n", "\n    "))
-        regs = get_pt_regs(task)
+        kstack = prog.stack_trace(thread)
+        if len(kstack) > 0 and (kstack[0].pc & (1 << 63)):
+            # Kernel stack is indeed a kernel stack, print it
+            print(
+                "    " + str(prog.stack_trace(thread)).replace("\n", "\n    ")
+            )
+            regs = task_saved_pt_regs(task)
+        else:
+            # CPU was in user-mode, print that instead:
+            print("    <running in user mode>")
+            regs = task_running_pt_regs(kstack)
         fake_regs = make_fake_pt_regs(user_prog, regs.to_bytes_())
         print_user_stack_trace(fake_regs)
 

--- a/drgn_tools/task.py
+++ b/drgn_tools/task.py
@@ -473,29 +473,14 @@ def for_each_task_in_group(
     :param include_self: should ``task`` itself be returned
     :returns: an iterable of every thread in the thread group
     """
-    if include_self:
-        yield task
-    if hasattr(task, "thread_group"):
-        yield from list_for_each_entry(
-            "struct task_struct",
-            task.thread_group.address_of_(),
-            "thread_group",
-        )
-    else:
-        # Since commit 8e1f385104ac0 ("kill task_struct->thread_group") from
-        # 6.7, the thread_group list is gone, replaced by a list inside the
-        # task.signal struct. This has an explicit list_head (unlike the
-        # thread_group which just linked each task together with no explicit
-        # head node).
-        for other in list_for_each_entry(
-            "struct task_struct",
-            task.signal.thread_head.address_of_(),
-            "thread_node",
-        ):
-            # We've already yielded "task" (or not, depending on the caller's
-            # preference) so skip it here.
-            if other != task:
-                yield other
+    # TODO: included in drgn 0.0.33
+    for other in list_for_each_entry(
+        "struct task_struct",
+        task.signal.thread_head.address_of_(),
+        "thread_node",
+    ):
+        if other != task or include_self:
+            yield other
 
 
 def count_tasks_in_state(prog: drgn.Program, state: str) -> int:

--- a/drgn_tools/util.py
+++ b/drgn_tools/util.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+import argparse
 import logging
 import re
 import sys
@@ -545,3 +546,24 @@ def per_cpu_owner(name: str, val: Object) -> int:
             return cpu
 
     return -1
+
+
+class CommaList(argparse.Action):
+    """Action that allows specifying an option multiple times, with comma-separated values"""
+
+    def __init__(self, *args, element_type=str, **kwargs) -> None:
+        self.element_type = element_type
+        return super().__init__(*args, **kwargs)
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        value: t.Union[str, t.Sequence[t.Any], None],
+        option_string: t.Optional[str] = None,
+    ) -> None:
+        assert isinstance(value, str)
+        result = getattr(namespace, self.dest, []) or []
+        for element in value.split(","):
+            result.append(self.element_type(element))
+        setattr(namespace, self.dest, result)

--- a/tests/test_pstack.py
+++ b/tests/test_pstack.py
@@ -15,6 +15,12 @@ from drgn_tools import pstack
 from drgn_tools.task import task_cpu
 
 
+pytestmark = [
+    # Only test UEK5+
+    pytest.mark.kver_min("4.14"),
+]
+
+
 @pytest.fixture
 def sleeping_proc():
     proc = Popen(

--- a/tests/test_pstack.py
+++ b/tests/test_pstack.py
@@ -1,0 +1,214 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+import argparse
+import gzip
+import sys
+from subprocess import PIPE
+from subprocess import Popen
+
+import pytest
+from drgn import Architecture
+from drgn.helpers.linux import task_state_to_char
+from drgn.helpers.linux.pid import find_task
+
+from drgn_tools import pstack
+from drgn_tools.task import task_cpu
+
+
+@pytest.fixture
+def sleeping_proc():
+    proc = Popen(
+        [sys.executable, "-c", "input('ready')"],
+        stdout=PIPE,
+        stdin=PIPE,
+    )
+    # Wait until it has printed the prompt, indicating it's likely sleeping
+    # waiting for input, and so the stack should be stable.
+    data = bytearray()
+    while b"ready" not in data:
+        data.extend(proc.stdout.read(1))
+    try:
+        yield proc
+    finally:
+        proc.terminate()
+        proc.wait()
+
+
+@pytest.mark.skip_vmcore("*")  # live only
+def test_task_saved_pt_regs(prog, sleeping_proc):
+    regs = pstack.task_saved_pt_regs(find_task(prog, sleeping_proc.pid))
+
+    # We can verify that the stack pointer points into a stack region of the
+    # task, and that the instruction pointer points into a mapped object file.
+    if prog.platform.arch == Architecture.X86_64:
+        pc = int(regs.ip)
+        sp = int(regs.sp)
+    else:
+        pc = int(regs.pc)
+        sp = int(regs.sp)
+
+    pc_found = sp_found = False
+    for line in open(f"/proc/{sleeping_proc.pid}/maps", "r"):
+        fields = line.split()
+        start = int(fields[0].split("-")[0], 16)
+        end = int(fields[0].split("-")[1], 16)
+        permission = fields[1]
+        file = fields[-1]
+
+        if start <= pc < end:
+            pc_found = True
+            # It must be an ELF file:
+            assert open(file, "rb").read(4) == b"\x7fELF"
+            # It must be an executable mapping:
+            assert "x" in permission
+        if start <= sp < end:
+            sp_found = True
+            # It must be in a stack region
+            assert file == "[stack]"
+
+    assert pc_found and sp_found
+
+
+def do_test_task_running_pt_regs(prog, task):
+    # Really, all task_running_pt_regs() does is take the registers dict from
+    # the top stack frame, and convert it into a "struct pt_regs" according to
+    # the particular architecture. So we can test its functionality on a kernel
+    # stack, rather than a user stack. Verify that the original stack trace
+    # matches the stack trace we get from the generated pt_regs.
+    orig_trace = prog.stack_trace(task)
+    pt_regs = pstack.task_running_pt_regs(orig_trace)
+    new_trace = prog.stack_trace(pt_regs)
+    assert len(orig_trace) == len(new_trace)
+    for orig, new in zip(orig_trace, new_trace):
+        assert orig.pc == new.pc
+
+
+@pytest.mark.skip_vmcore("*")  # live only
+def test_task_running_pt_regs_live(prog, sleeping_proc):
+    task = find_task(prog, sleeping_proc.pid)
+    do_test_task_running_pt_regs(prog, task)
+
+
+@pytest.mark.skip_live
+def test_task_running_pt_regs_vmcore(prog, sleeping_proc):
+    task = find_task(prog, 1)
+    do_test_task_running_pt_regs(prog, task)
+
+
+def build_args(
+    output,
+    max_stack_bytes=1024 * 1024,
+    comm=None,
+    state=None,
+    all=False,
+    online=False,
+    pid=None,
+):
+    if comm is not None:
+        comm = []
+    if state is not None:
+        state = []
+    if pid is not None:
+        state = []
+
+    return argparse.Namespace(
+        output=output,
+        max_stack_bytes=max_stack_bytes,
+        comm=comm,
+        state=state,
+        all=all,
+        online=online,
+        pid=pid,
+    )
+
+
+@pytest.mark.skip_vmcore("*")  # live only
+def test_dump(prog, tmp_path, sleeping_proc):
+    pid = sleeping_proc.pid
+    pstack.dump(prog, build_args(tmp_path / "dump", pid=[pid]))
+    with gzip.open(tmp_path / "dump", "rb") as f:
+        magic = f.read(8)
+        assert magic == b"pstack\x00\x01"
+
+        metadata = pstack.read_json_object(f)
+        assert metadata == {"page_size": int(prog["PAGE_SIZE"])}
+
+        task_meta = pstack.read_json_object(f)
+        assert task_meta["pid"] == sleeping_proc.pid
+        assert task_meta["comm"] == open(f"/proc/{pid}/comm").read().strip()
+        assert not task_meta["kernel"]
+        assert len(task_meta["threads"]) == 1
+
+        # Get executables from /proc/{pid}/maps and compare with the metadata
+        executables = []
+        start_addr = 0
+        for line in open(f"/proc/{pid}/maps"):
+            fields = line.split(maxsplit=5)
+            if len(fields) != 6:
+                continue
+            filename = fields[-1].rstrip()
+            if filename[0] == "[":
+                continue
+            if int(fields[2], 16) == 0:
+                start_addr = int(fields[0].split("-")[0], 16)
+            if "x" in fields[1] and start_addr != 0:
+                executables.append((filename, start_addr))
+                start_addr = 0
+        assert len(executables) == len(task_meta["mm"])
+        for filename, start_addr in executables:
+            assert task_meta["mm"][filename][0] == start_addr
+
+        # Now ensure the thread metadata is correct:
+        thread = task_meta["threads"][0]
+        assert thread["tid"] == pid
+        assert thread["comm"] == task_meta["comm"]
+        assert thread["kstack"] == str(prog.stack_trace(pid))
+        assert thread["cpu"] == task_cpu(find_task(prog, pid))
+        assert not thread["on_cpu"]
+        assert thread["state"] == "S"
+
+        # Now ensure we have some stack data. Not too much verification of
+        # correctness here, just want to ensure it is done correctly.
+        end = b"\xff" * 8
+        pgsize = int(prog["PAGE_SIZE"])
+        while True:
+            header = f.read(8)
+            assert len(header) == 8
+            if header == end:
+                break
+            assert len(f.read(pgsize)) == pgsize
+
+        # EOF
+        assert f.read() == b""
+
+
+@pytest.mark.skip_vmcore("*")  # live only
+def test_read_dump(prog, tmp_path, sleeping_proc, capsys):
+    pid = sleeping_proc.pid
+    pstack.dump(prog, build_args(tmp_path / "dump", pid=[pid]))
+    capsys.readouterr()
+
+    pstack.dump_print(tmp_path / "dump")
+    stdout_from_dump = capsys.readouterr().out
+    pstack.pstack_print_process(find_task(prog, pid))
+    print()
+    stdout_from_pstack = capsys.readouterr().out
+    assert stdout_from_dump == stdout_from_pstack
+
+
+def test_get_tasks_pid(prog):
+    args = build_args("IGNORE", pid=[1])
+    result = pstack.get_tasks(prog, args)
+    assert len(result) == 1
+    assert result[0].pid.value_() == 1
+
+
+@pytest.mark.skip_live  # this will flake on live systems
+def test_get_tasks_state_and_pid(prog):
+    args = build_args("IGNORE", pid=[1], state=["R"])
+    result = pstack.get_tasks(prog, args)
+    found_init = False
+    for task in result:
+        assert task_state_to_char(task) == "R" or task.pid.value_() == 1
+        found_init = found_init or task.pid.value_() == 1
+    assert found_init


### PR DESCRIPTION
This imports the pstack contrib script from drgn, and updates it. I'll end up pushing many of these updates back to drgn as well, but the main things are:

1. It is now tested on aarch64 and works with minimal changes.
2. Tasks that are running in user-mode on CPU can now be unwound and printed correctly.
3. Task state selection is done so that multiple pids, command patterns, or task states can be specified very flexibly.
4. For the "dump" mode, all task data is dumped to a single file, rather than several files per PID.