### PR TITLE
Small fixes

### DIFF
--- a/drgn_tools/dentry.py
+++ b/drgn_tools/dentry.py
@@ -12,6 +12,7 @@ from typing import Optional
 import drgn
 from drgn import Object
 from drgn import Program
+from drgn.helpers.common.format import escape_ascii_string
 from drgn.helpers.linux import d_path
 from drgn.helpers.linux.fs import path_lookup
 from drgn.helpers.linux.list import hlist_for_each_entry
@@ -239,7 +240,7 @@ def print_dentry_table(
                 d.d_inode.value_(),
                 int(d_count(d)),
                 file_type,
-                d_path(d).decode(),
+                escape_ascii_string(d_path(d)),
             )
         else:
             table.row(
@@ -247,7 +248,7 @@ def print_dentry_table(
                 d.d_sb.value_(),
                 d.d_inode.value_(),
                 file_type,
-                d_path(d).decode(),
+                escape_ascii_string(d_path(d)),
             )
 
 
@@ -374,7 +375,7 @@ def ls(
     print(f"{directory}:")
     pos = neg = 0
     for i, dentry in enumerate(dentries):
-        name = dentry.d_name.name.string_().decode()
+        name = escape_ascii_string(dentry.d_name.name.string_())
         if dentry_is_negative(dentry):
             neg += 1
             dentry_type = "NEG"
@@ -474,5 +475,5 @@ class DentryCache(CorelensModule):
         else:
             # Emulate oled dentrycache
             for i, dentry in enumerate(dentries):
-                path = d_path(dentry).decode()
+                path = escape_ascii_string(d_path(dentry))
                 print(f"{i:05d} {path}")

--- a/drgn_tools/meminfo.py
+++ b/drgn_tools/meminfo.py
@@ -509,7 +509,9 @@ def get_all_meminfo(prog: Program) -> Dict[str, int]:
     stats["NFS_Unstable"] = 0
     if "NR_UNSTABLE_NFS" in global_stats:
         stats["NFS_Unstable"] = global_stats["NR_UNSTABLE_NFS"]
-    stats["Bounce"] = global_stats["NR_BOUNCE"]
+    # Since 194df9f66db8d ("mm: remove NR_BOUNCE zone stat") in v6.16, NR_BOUNCE
+    # is removed from stats and set to zero.
+    stats["Bounce"] = global_stats.get("NR_BOUNCE", 0)
     stats["WritebackTmp"] = global_stats["NR_WRITEBACK_TEMP"]
 
     stats["CommitLimit"] = get_vm_commit_limit(prog)

--- a/drgn_tools/numastat.py
+++ b/drgn_tools/numastat.py
@@ -89,7 +89,9 @@ def get_per_node_meminfo(prog: Program, node: Object) -> Dict[str, int]:
 
     totalram_pages = node_zone_stats["NR_MANAGED_PAGES"]
     freeram_pages = node_zone_stats["NR_FREE_PAGES"]
-    bounce_pages = node_zone_stats["NR_BOUNCE"]
+    # Since 194df9f66db8d ("mm: remove NR_BOUNCE zone stat") in v6.16, NR_BOUNCE
+    # is removed from stats and set to zero.
+    bounce_pages = node_zone_stats.get("NR_BOUNCE", 0)
     mlocked_pages = node_zone_stats["NR_MLOCK"]
 
     slab_reclaimable = node_zone_stats["NR_SLAB_RECLAIMABLE"]

--- a/drgn_tools/printk.py
+++ b/drgn_tools/printk.py
@@ -6,6 +6,7 @@ Additional helpers for printk utilities
 import argparse
 import os
 import subprocess
+import sys
 from typing import Optional
 
 from drgn import Program
@@ -42,4 +43,8 @@ class DmesgModule(CorelensModule):
     name = "dmesg"
 
     def run(self, prog: Program, args: argparse.Namespace) -> None:
-        print(get_dmesg(prog).decode("utf-8"))
+        # Avoid the overhead of decoding and then re-encoding the bytes: just
+        # write the bytes directly to stdout. Also, avoid any encoding errors.
+        # There's no guaranteed encoding for the kernel log anyway.
+        sys.stdout.buffer.write(get_dmesg(prog))
+        print()


### PR DESCRIPTION
Three small fixes here. Two relate to string encoding and decoding. We've sometimes done a bit of unnecessary (or even harmful) `str.decode()` operations. Many kinds of data in the kernel (filenames, printk buffer) don't have guaranteed encodings, so decoding with the utf-8 encoding is not the right call. The right way is either to keep the data in `bytes` if possible, or else use `escape_ascii_string()` if we expect it to be text and we want to include it in text-mode/string output.

The last fix is for a change in 6.16 that has broken the test framework.