### PR TITLE
add helpers to dump max inflight io time for one disk and its disk driver

### DIFF
--- a/.header.txt
+++ b/.header.txt
@@ -1,2 +1,2 @@
-# Copyright (c) 2025, Oracle and/or its affiliates.
+# Copyright (c) 2026, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/

--- a/drgn_tools/block.py
+++ b/drgn_tools/block.py
@@ -5,7 +5,6 @@ Helpers for block layers.
 
 No kernel modules are required since uek built in all io schduler modules.
 """
-import argparse
 from typing import Iterable
 from typing import Tuple
 
@@ -24,11 +23,8 @@ from drgn.helpers.linux.timekeeping import ktime_get_coarse_ns
 from drgn.helpers.linux.xarray import xa_for_each
 
 from drgn_tools.bitops import for_each_bit_set
-from drgn_tools.corelens import CorelensModule
-from drgn_tools.table import print_table
 from drgn_tools.util import has_member
 from drgn_tools.util import percpu_ref_sum
-from drgn_tools.util import timestamp_str
 from drgn_tools.util import type_exists
 
 BB_LEN_MASK = 0x00000000000001FF
@@ -624,52 +620,3 @@ def queue_freezed_depth(q: Object) -> int:
 
 def queue_usage_counter(q: Object) -> int:
     return percpu_ref_sum(q.prog_, q.q_usage_counter)
-
-
-def print_block_devs_info(prog: drgn.Program) -> None:
-    """
-    Prints the block device information
-    """
-    output = [
-        [
-            "MAJOR",
-            "GENDISK",
-            "NAME",
-            "REQUEST_QUEUE",
-            "Inflight I/Os",
-            "Max Inflight time",
-            "Freezed Depth",
-            "Usage Counter",
-        ]
-    ]
-    for disk in for_each_disk(prog):
-        q = disk.queue
-        major = int(disk.major)
-        gendisk = hex(disk.value_())
-        name = disk.disk_name.string_().decode("utf-8")
-        rq = hex(q.value_())
-        ios = get_inflight_io_nr(prog, disk)
-        output.append(
-            [
-                str(major),
-                gendisk,
-                name,
-                rq,
-                str(ios),
-                timestamp_str(get_max_io_inflight_ns(prog, disk)),
-                str(queue_freezed_depth(q)),
-                str(queue_usage_counter(q)),
-            ]
-        )
-    print_table(output)
-
-
-class BlockInfo(CorelensModule):
-    """
-    Corelens Module for block device info
-    """
-
-    name = "blockinfo"
-
-    def run(self, prog: drgn.Program, args: argparse.Namespace) -> None:
-        print_block_devs_info(prog)

--- a/drgn_tools/block.py
+++ b/drgn_tools/block.py
@@ -28,6 +28,7 @@ from drgn_tools.corelens import CorelensModule
 from drgn_tools.table import print_table
 from drgn_tools.util import has_member
 from drgn_tools.util import percpu_ref_sum
+from drgn_tools.util import timestamp_str
 from drgn_tools.util import type_exists
 
 BB_LEN_MASK = 0x00000000000001FF
@@ -576,6 +577,43 @@ def get_inflight_io_nr(prog: drgn.Program, disk: Object) -> int:
     return int(nr)
 
 
+def get_max_io_inflight_ns(prog: drgn.Program, disk: Object) -> int:
+    """
+    Get max io inflight time for some disk
+
+    :param prog: drgn program
+    :param disk: ``struct gendisk *``
+    :returns: max io inflight time in nano seconds
+    """
+    rq_pending = []
+    q = disk.queue
+    if not is_mq(q):
+        rq_pending += [rq[0].read_() for rq in for_each_sq_pending_request(q)]
+    else:
+        try:
+            BLK_MQ_F_TAG_SHARED = prog.constant("BLK_MQ_F_TAG_SHARED")
+        except LookupError:
+            BLK_MQ_F_TAG_SHARED = prog.constant("BLK_MQ_F_TAG_QUEUE_SHARED")
+
+        mq_pending = [
+            (hwq[0].read_(), rq[0].read_())
+            for hwq, rq in for_each_mq_pending_request(q)
+        ]
+        for hwq, rq in mq_pending:
+            if (hwq.flags & BLK_MQ_F_TAG_SHARED) != 0 and request_target(
+                rq
+            ).value_() != disk.value_():
+                continue
+            rq_pending.append(rq)
+
+    max_ns = 0
+    for rq in rq_pending:
+        if rq_pending_time_ns(rq) > max_ns:
+            max_ns = rq_pending_time_ns(rq)
+
+    return max_ns
+
+
 def queue_freezed_depth(q: Object) -> int:
     depth = q.mq_freeze_depth
     if depth.type_.kind == TypeKind.INT:
@@ -599,6 +637,7 @@ def print_block_devs_info(prog: drgn.Program) -> None:
             "NAME",
             "REQUEST_QUEUE",
             "Inflight I/Os",
+            "Max Inflight time",
             "Freezed Depth",
             "Usage Counter",
         ]
@@ -617,6 +656,7 @@ def print_block_devs_info(prog: drgn.Program) -> None:
                 name,
                 rq,
                 str(ios),
+                timestamp_str(get_max_io_inflight_ns(prog, disk)),
                 str(queue_freezed_depth(q)),
                 str(queue_usage_counter(q)),
             ]

--- a/drgn_tools/blockinfo.py
+++ b/drgn_tools/blockinfo.py
@@ -1,8 +1,10 @@
 # Copyright (c) 2026, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 import argparse
+import re
 
 import drgn
+from drgn import Object
 from drgn.helpers.linux.block import for_each_disk
 
 from drgn_tools.block import get_inflight_io_nr
@@ -10,8 +12,43 @@ from drgn_tools.block import get_max_io_inflight_ns
 from drgn_tools.block import queue_freezed_depth
 from drgn_tools.block import queue_usage_counter
 from drgn_tools.corelens import CorelensModule
+from drgn_tools.dm import dm_target_driver
+from drgn_tools.md import md_raid_driver
+from drgn_tools.nvme import nvme_disk_driver
+from drgn_tools.scsi import scsi_disk_driver
 from drgn_tools.table import print_table
 from drgn_tools.util import timestamp_str
+
+
+def get_disk_type(disk: Object) -> str:
+    diskname = disk.disk_name.string_().decode()
+    patterns = {
+        "nvme": r"^nvme\d+(n\d+)?$",
+        "scsi": r"^sd[a-z]+$",
+        "md": r"^md\d+$",
+        "dm": r"^dm-\d+$",
+        "loop": r"^loop\d+$",
+        "pmem": r"^pmem\d+$",
+    }
+    for dtype, pattern in patterns.items():
+        if re.match(pattern, diskname):
+            return dtype
+
+    return "unknown"
+
+
+def get_disk_driver(prog: drgn.Program, disk: Object) -> str:
+    dtype = get_disk_type(disk)
+    if dtype == "nvme":
+        return nvme_disk_driver(prog, disk)
+    elif dtype == "scsi":
+        return scsi_disk_driver(prog, disk)
+    elif dtype == "md":
+        return md_raid_driver(prog, disk)
+    elif dtype == "dm":
+        return dm_target_driver(prog, disk)
+    else:
+        return dtype
 
 
 def print_block_devs_info(prog: drgn.Program) -> None:
@@ -23,6 +60,7 @@ def print_block_devs_info(prog: drgn.Program) -> None:
             "MAJOR",
             "GENDISK",
             "NAME",
+            "DRIVER",
             "REQUEST_QUEUE",
             "Inflight I/Os",
             "Max Inflight time",
@@ -42,6 +80,7 @@ def print_block_devs_info(prog: drgn.Program) -> None:
                 str(major),
                 gendisk,
                 name,
+                get_disk_driver(prog, disk),
                 rq,
                 str(ios),
                 timestamp_str(get_max_io_inflight_ns(prog, disk)),

--- a/drgn_tools/blockinfo.py
+++ b/drgn_tools/blockinfo.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+import argparse
+
+import drgn
+from drgn.helpers.linux.block import for_each_disk
+
+from drgn_tools.block import get_inflight_io_nr
+from drgn_tools.block import get_max_io_inflight_ns
+from drgn_tools.block import queue_freezed_depth
+from drgn_tools.block import queue_usage_counter
+from drgn_tools.corelens import CorelensModule
+from drgn_tools.table import print_table
+from drgn_tools.util import timestamp_str
+
+
+def print_block_devs_info(prog: drgn.Program) -> None:
+    """
+    Prints the block device information
+    """
+    output = [
+        [
+            "MAJOR",
+            "GENDISK",
+            "NAME",
+            "REQUEST_QUEUE",
+            "Inflight I/Os",
+            "Max Inflight time",
+            "Freezed Depth",
+            "Usage Counter",
+        ]
+    ]
+    for disk in for_each_disk(prog):
+        q = disk.queue
+        major = int(disk.major)
+        gendisk = hex(disk.value_())
+        name = disk.disk_name.string_().decode("utf-8")
+        rq = hex(q.value_())
+        ios = get_inflight_io_nr(prog, disk)
+        output.append(
+            [
+                str(major),
+                gendisk,
+                name,
+                rq,
+                str(ios),
+                timestamp_str(get_max_io_inflight_ns(prog, disk)),
+                str(queue_freezed_depth(q)),
+                str(queue_usage_counter(q)),
+            ]
+        )
+    print_table(output)
+
+
+class BlockInfo(CorelensModule):
+    """
+    Corelens Module for block device info
+    """
+
+    name = "blockinfo"
+
+    def run(self, prog: drgn.Program, args: argparse.Namespace) -> None:
+        print_block_devs_info(prog)

--- a/drgn_tools/dm.py
+++ b/drgn_tools/dm.py
@@ -164,6 +164,17 @@ def dm_target_name(dm: Object) -> str:
     return table.targets.type.name.string_().decode()
 
 
+def dm_target_driver(prog: Program, disk: Object) -> str:
+    diskname = disk.disk_name.string_().decode()
+    if not diskname.startswith("dm-"):
+        return "unknown"
+    dm = Object(
+        prog, "struct mapped_device *", value=disk.private_data.value_()
+    )
+
+    return dm_target_name(dm)
+
+
 def show_table_linear(dm: Object, name: str) -> None:
     table = dm_table(dm)
     for tid in range(table.num_targets):

--- a/drgn_tools/inflightio.py
+++ b/drgn_tools/inflightio.py
@@ -21,12 +21,16 @@ from drgn_tools.util import has_member
 from drgn_tools.util import timestamp_str
 
 
-def dump_nvme_mgmt_inflight_io(prog: drgn.Program, qtype: str) -> None:
+def dump_nvme_mgmt_inflight_io(
+    prog: drgn.Program, qtype: str, diskname: str = "all"
+) -> None:
     """
     Dump inflight io from NVMe's management queue
 
     :param prog: drgn program
     :param qtype: managment queue name, "admin", "connect" or "fabrics"
+    :param diskname: nvme$X-$qtype, where "X" is controller ID, "qtype" is one of the above,
+                     or "all" for all nvme disks on all management queues.
     """
     for ctrl in for_each_nvme_ctrl(prog):
         if qtype == "admin" and ctrl.admin_q.value_():
@@ -52,6 +56,9 @@ def dump_nvme_mgmt_inflight_io(prog: drgn.Program, qtype: str) -> None:
             name = "nvme" + str(ctrl.instance.value_()) + "-fabrics"
         else:
             return
+
+        if diskname != "all" and diskname != name:
+            continue
 
         mq_pending = [
             (hwq.value_(), hwq[0].read_(), rq.value_(), rq[0].read_())
@@ -154,10 +161,9 @@ def dump_inflight_io(prog: drgn.Program, diskname: str = "all") -> None:
             )
 
     # dump nvme management inflight IO
-    if diskname == "all":
-        dump_nvme_mgmt_inflight_io(prog, "admin")
-        dump_nvme_mgmt_inflight_io(prog, "connect")
-        dump_nvme_mgmt_inflight_io(prog, "fabrics")
+    dump_nvme_mgmt_inflight_io(prog, "admin", diskname)
+    dump_nvme_mgmt_inflight_io(prog, "connect", diskname)
+    dump_nvme_mgmt_inflight_io(prog, "fabrics", diskname)
 
 
 class InflightIOModule(CorelensModule):

--- a/drgn_tools/md.py
+++ b/drgn_tools/md.py
@@ -26,7 +26,12 @@ def md_raid_driver(prog: Program, disk: Object) -> str:
     if not diskname.startswith("md"):
         return "unknown"
     mddev = Object(prog, "struct mddev *", value=disk.private_data.value_())
-    return mddev.pers.owner.name.string_().decode()
+    pers = mddev.pers
+    if has_member(pers, "owner"):
+        return pers.owner.name.string_().decode()
+    else:
+        # v6.15 commit d3beb7c9c61d2("md: introduce struct md_submodule_head and APIs")
+        return pers.head.owner.name.string_().decode()
 
 
 def for_each_md(prog: Program) -> Iterable[Object]:

--- a/drgn_tools/md.py
+++ b/drgn_tools/md.py
@@ -21,6 +21,14 @@ from drgn_tools.util import has_member
 from drgn_tools.util import percpu_ref_sum
 
 
+def md_raid_driver(prog: Program, disk: Object) -> str:
+    diskname = disk.disk_name.string_().decode()
+    if not diskname.startswith("md"):
+        return "unknown"
+    mddev = Object(prog, "struct mddev *", value=disk.private_data.value_())
+    return mddev.pers.owner.name.string_().decode()
+
+
 def for_each_md(prog: Program) -> Iterable[Object]:
     """
     List all soft raid disk in the system

--- a/drgn_tools/nvme.py
+++ b/drgn_tools/nvme.py
@@ -21,6 +21,23 @@ from drgn_tools.table import print_table
 from drgn_tools.util import enum_name_get
 
 
+def nvme_ctrl(prog: Program, disk: Object) -> Object:
+    diskname = disk.disk_name.string_().decode()
+    if not diskname.startswith("nvme"):
+        return None
+
+    q = disk.queue
+    ns = Object(prog, "struct nvme_ns *", value=q.queuedata.value_())
+    return ns.ctrl
+
+
+def nvme_disk_driver(prog: Program, disk: Object) -> str:
+    ctrl = nvme_ctrl(prog, disk)
+    if not ctrl:
+        return "unknown"
+    return ctrl.ops.module.name.string_().decode()
+
+
 def for_each_nvme_disk(prog: Program) -> Iterable[Object]:
     """
     Return each NVMe device

--- a/drgn_tools/scsi.py
+++ b/drgn_tools/scsi.py
@@ -76,6 +76,19 @@ def host_module_name(shost: Object) -> str:
     return name
 
 
+def scsi_host(prog: Program, disk: Object) -> Object:
+    diskname = disk.disk_name.string_().decode()
+    if not diskname.startswith("sd"):
+        return None
+    q = disk.queue
+    sdev = Object(prog, "struct scsi_device *", value=q.queuedata.value_())
+    return sdev.host
+
+
+def scsi_disk_driver(prog: Program, disk: Object) -> str:
+    return host_module_name(scsi_host(prog, disk))
+
+
 def for_each_scsi_host_device(shost: Object) -> Iterator[Object]:
     """
     Iterates thru all scsi device and returns a scsi_device address

--- a/tests/test_blockinfo.py
+++ b/tests/test_blockinfo.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
-from drgn_tools import block
+from drgn_tools import blockinfo
 
 
 def test_blockinfo(prog):
-    block.print_block_devs_info(prog)
+    blockinfo.print_block_devs_info(prog)


### PR DESCRIPTION
Two columns "DRIVER" and "Max Inflight time" are added.

```
>>> from drgn_tools import blockinfo
>>> blockinfo.print_block_devs_info(prog)
MAJOR  GENDISK             NAME   DRIVER       REQUEST_QUEUE       Inflight I/Os  Max Inflight time  Freezed Depth  Usage Counter
8      0xffff99155b391a00  sda    virtio_scsi  0xffff99154b323990  0              0 00:00:00.000     0              1
252    0xffff99154105c000  dm-0   linear       0xffff99154b321cc8  0              0 00:00:00.000     0              1
252    0xffff9915425e2200  dm-1   linear       0xffff9915c967d658  0              0 00:00:00.000     0              1
8      0xffff9915428ad800  sdb    iscsi_tcp    0xffff99154b320998  0              0 00:00:00.000     0              1
8      0xffff991547dfe800  sdc    iscsi_tcp    0xffff99154b320000  24             0 00:00:00.418     0              30
7      0xffff9915c95ba000  loop0  loop         0xffff9915c96d2ff8  110            0 00:00:16.316     0              111
9      0xffff991547e46c00  md0    raid456      0xffff9915c967dff0  0              0 00:00:00.000     0              4
7      0xffff99154611b200  loop1  loop         0xffff9915c96d0998  48             0 00:00:03.658     0              49
7      0xffff991558d6f000  loop2  loop         0xffff9915c967f320  123            0 00:00:09.403     0              125
7      0xffff9915428acc00  loop3  loop         0xffff9915c96d4328  12             0 00:00:03.990     0              13
7      0xffff99154089d400  loop4  loop         0xffff9915c96d0000  32             0 00:00:02.074     0              33
7      0xffff991542f5d400  loop5  loop         0xffff99154b322660  34             0 00:00:32.587     0              38
7      0xffff991548970000  loop6  loop         0xffff9915c96d1330  118            0 00:00:31.792     0              119
7      0xffff9915594d5200  loop7  loop         0xffff9915c9679330  128            0 00:00:36.261     0              131
9      0xffff9915494cf400  md1    raid1        0xffff991592393990  0              0 00:00:00.000     0              1
9      0xffff99154ab67400  md2    raid0        0xffff991592391330  0              0 00:00:00.000     0              1
>>>
```