### PR TITLE
New test runner

### DIFF
--- a/.github/workflows/litevm.yml
+++ b/.github/workflows/litevm.yml
@@ -25,48 +25,37 @@ jobs:
       - name: Run pre-commit hooks
         run: pre-commit run --all-files --show-diff-on-failure
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Our minimum supported version of Python is 3.6, used by Oracle Linux 7
-        # & 8. Ideally we would run tests on that, along with Python 3.9 for
-        # Oracle Linux 9, and maybe Python 3.12 for an upcoming Oracle Linux 10.
-        # However, practicality rules here. The binutils provided in Ubuntu
-        # 20.04 is not recent enough for our libctf usage, but 20.04 is the only
-        # remaining Ubuntu image with Python 3.6 available in Github actions.
-        # So we have to eliminate Python 3.6 from our test matrix. Other CI
-        # tests do run on Python 3.6, and there is the "vermin" pre-commit hook
-        # which detects code incompatible with 3.6.
-        python-minor: ["9", "12"]
+        ol-version: [8, 9, 10]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.${{ matrix.python-minor }}
+          python-version: 3.12
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install qemu-kvm zstd gzip bzip2 cpio busybox-static fio \
-                               autoconf automake check gcc git liblzma-dev \
-                               libelf-dev libdw-dev libtool make pkgconf zlib1g-dev \
-                               binutils-dev rpm2cpio libpcre2-dev
+          sudo apt-get install qemu-kvm qemu-system-common zstd gzip bzip2 cpio \
+                               busybox-static fio rpm2cpio podman
       - name: Setup test environment
-        # Pinned virtualenv and tox are for the last versions which support
-        # detecting Python 3.6 and running tests on it.
+        # We install drgn here to satisfy imports. The version doesn't really
+        # matter, because this is not the version of drgn we actually use for
+        # testing. Instead, we use the latest drgn RPM from Oracle Linux in the
+        # test rootfs..
         run: |
           python -m venv venv
-          venv/bin/pip install -r testing/requirements-litevm.txt
-          venv/bin/pip install setuptools
-      - name: Build and install drgn with CTF support
+          venv/bin/pip install drgn
+      - name: Enable unprivileged user namespace cloning
+        # The test environment depends on unprivileged user namespaces. Ubuntu
+        # 24 introduces AppArmor profiles that get in the way.
         run: |
-          cd ..
-          git clone https://github.com/brenns10/drgn -b ctf_0.1.0
-          cd drgn
-          ../drgn-tools/venv/bin/pip install .
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
       - name: Run tests
         env:
           DRGN_TOOLS_ALLOW_MISSING_LATEST: ${{ contains(github.event.pull_request.labels.*.name, 'allow-missing-latest') && '1' || '0' }}
         run: |
-          venv/bin/python -m testing.litevm.vm --delete-after-test --with-ctf
+          venv/bin/python -m testing.vm.runner -iv -k ol${{ matrix.ol-version }}-*-x86_64

--- a/.github/workflows/litevm.yml
+++ b/.github/workflows/litevm.yml
@@ -49,11 +49,18 @@ jobs:
         run: |
           python -m venv venv
           venv/bin/pip install drgn
-      - name: Enable unprivileged user namespace cloning
+      - name: Configure permissions
         # The test environment depends on unprivileged user namespaces. Ubuntu
         # 24 introduces AppArmor profiles that get in the way.
+        #
+        # Similarly, /dev/kvm needs to be world-read-writable. See also drgn's
+        # test framework.
         run: |
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          ls -lh /dev/kvm
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /lib/udev/rules.d/99-fix-kvm.rules > /dev/null
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger -w /dev/kvm
       - name: Run tests
         env:
           DRGN_TOOLS_ALLOW_MISSING_LATEST: ${{ contains(github.event.pull_request.labels.*.name, 'allow-missing-latest') && '1' || '0' }}

--- a/.github/workflows/litevm.yml
+++ b/.github/workflows/litevm.yml
@@ -58,4 +58,4 @@ jobs:
         env:
           DRGN_TOOLS_ALLOW_MISSING_LATEST: ${{ contains(github.event.pull_request.labels.*.name, 'allow-missing-latest') && '1' || '0' }}
         run: |
-          venv/bin/python -m testing.vm.runner -iv -k ol${{ matrix.ol-version }}-*-x86_64
+          venv/bin/python -m testing.vm.runner --delete-after-test -iv -k ol${{ matrix.ol-version }}-*-x86_64

--- a/.github/workflows/litevm.yml
+++ b/.github/workflows/litevm.yml
@@ -58,4 +58,4 @@ jobs:
         env:
           DRGN_TOOLS_ALLOW_MISSING_LATEST: ${{ contains(github.event.pull_request.labels.*.name, 'allow-missing-latest') && '1' || '0' }}
         run: |
-          venv/bin/python -m testing.vm.runner --delete-after-test -iv -k ol${{ matrix.ol-version }}-*-x86_64
+          venv/bin/python -m testing.vm.runner --delete-after-test -v -k ol${{ matrix.ol-version }}-*-x86_64

--- a/.github/workflows/litevm.yml
+++ b/.github/workflows/litevm.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install qemu-kvm qemu-system-common zstd gzip bzip2 cpio \
+          sudo apt-get install qemu-kvm virtiofsd zstd gzip bzip2 cpio \
                                busybox-static fio rpm2cpio podman
       - name: Setup test environment
         # We install drgn here to satisfy imports. The version doesn't really

--- a/drgn_tools/meminfo.py
+++ b/drgn_tools/meminfo.py
@@ -572,8 +572,10 @@ def get_all_meminfo(prog: Program) -> Dict[str, int]:
         stats["FileHugePages"] = -1
         stats["FilePmdMapped"] = -1
 
-    stats["CmaTotal"] = prog["totalcma_pages"].value_()
-    stats["CmaFree"] = global_stats["NR_FREE_CMA_PAGES"]
+    migratetype_names = [n.string_() for n in prog["migratetype_names"]]
+    if b"CMA" in migratetype_names:
+        stats["CmaTotal"] = prog["totalcma_pages"].value_()
+        stats["CmaFree"] = global_stats["NR_FREE_CMA_PAGES"]
     return stats
 
 
@@ -651,8 +653,11 @@ def show_all_meminfo(prog: Program) -> None:
         else:
             print_val_kb(prog, item, stats[item])
 
-    for item in hugepage_meminfo_items + cma_meminfo_items:
+    for item in hugepage_meminfo_items:
         print_val_kb(prog, item, stats[item])
+    for item in cma_meminfo_items:
+        if item in stats:
+            print_val_kb(prog, item, stats[item])
 
     # Report hugepage related meminfo
     show_hugetlb_meminfo(prog)

--- a/testing/kmod/.gitignore
+++ b/testing/kmod/.gitignore
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+Module.symvers
+modules.order
+.*.cmd
+*.ko
+*.o
+*.d
+*.mod*

--- a/testing/kmod/Makefile
+++ b/testing/kmod/Makefile
@@ -1,0 +1,3 @@
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+obj-m := drgntools_test.o

--- a/testing/kmod/drgntools_test.c
+++ b/testing/kmod/drgntools_test.c
@@ -1,6 +1,15 @@
 // Copyright (c) 2026, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+#include <linux/export.h>
 #include <linux/module.h>
+
+struct drgn_tools_test_object {
+	int foo;
+	const char *bar;
+};
+
+struct drgn_tools_test_object drgn_tools_test_object_data = { 5, "foobar" };
+EXPORT_SYMBOL(drgn_tools_test_object_data);
 
 static int __init drgntools_init(void)
 {

--- a/testing/kmod/drgntools_test.c
+++ b/testing/kmod/drgntools_test.c
@@ -1,0 +1,20 @@
+// Copyright (c) 2026, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+#include <linux/module.h>
+
+static int __init drgntools_init(void)
+{
+	printk(KERN_INFO "drgntools_test: hello world\n");
+	return 0;
+}
+
+static void __exit drgntools_exit(void)
+{
+}
+
+module_init(drgntools_init);
+module_exit(drgntools_exit);
+
+MODULE_AUTHOR("Stephen Brennan <stephen.s.brennan@oracle.com>");
+MODULE_DESCRIPTION("Testing fixtures for drgn-tools");
+MODULE_LICENSE("UPL");

--- a/testing/litevm/rpm.py
+++ b/testing/litevm/rpm.py
@@ -332,6 +332,7 @@ TEST_KERNELS = [
             "kernel-ueknext-core",
             "kernel-ueknext-modules",
             "kernel-ueknext-modules-core",
+            "kernel-ueknext-devel",
         ],
         yum_fmt=(
             "https://yum.oracle.com/repo/OracleLinux/OL{ol_ver}/"
@@ -344,17 +345,27 @@ TEST_KERNELS = [
         9,
         8,
         "x86_64",
-        ["kernel-uek-core", "kernel-uek-modules", "kernel-uek-modules-core"],
+        [
+            "kernel-uek-core",
+            "kernel-uek-modules",
+            "kernel-uek-modules-core",
+            "kernel-uek-devel",
+        ],
     ),
     # UEK7 switches from a single "kernel-uek" to "-core" and "-modules".
     # The "kernel-uek" package still exists as a placeholder.
-    TestKernel(9, 7, "x86_64", ["kernel-uek-core", "kernel-uek-modules"]),
-    TestKernel(8, 6, "x86_64", ["kernel-uek"]),
+    TestKernel(
+        9,
+        7,
+        "x86_64",
+        ["kernel-uek-core", "kernel-uek-modules", "kernel-uek-devel"],
+    ),
+    TestKernel(8, 6, "x86_64", ["kernel-uek", "kernel-uek-devel"]),
     # UEK5 is based on 4.14. 9p is available and supported here, but
     # unfortunately the UEK kernel configuration does not enable CONFIG_9P_FS.
     # Thankfully, this can be resolved by simply building the module
     # out-of-tree.
-    TestKernel(7, 5, "x86_64", ["kernel-uek"]),
+    TestKernel(7, 5, "x86_64", ["kernel-uek", "kernel-uek-devel"]),
     # UEK4 is based on 4.1. Unfortunately, 9p is not supported as an overlay
     # lower filesystem here. The changes required in order to make overlayfs
     # support 9p are too invasive; we can't simply replace the overlay module

--- a/testing/litevm/rpm.py
+++ b/testing/litevm/rpm.py
@@ -5,7 +5,6 @@ RPM Fetching for Tests
 """
 import argparse
 import fnmatch
-import io
 import os
 import shlex
 import shutil
@@ -74,9 +73,7 @@ def download_file_cached(
     """
     if not cache:
         cache = YUM_CACHE_DIR
-    if cache_key:
-        cache = cache / cache_key
-    cached_file = cache / url.split("/")[-1]
+    cached_file = cached_file_path(url, cache, cache_key)
     cached_file.parent.mkdir(exist_ok=True, parents=True)
     if not cached_file.is_file():
         if cache_key and delete_on_miss and cached_file.parent.is_dir():
@@ -87,7 +84,7 @@ def download_file_cached(
                 download_file(url, cache_f, quiet=quiet, desc=desc)
             except BaseException:
                 # Yes, BaseException is correct. If we're interrupted for _any_
-                # reason, our cached downolad is invalid and must be removed.
+                # reason, our cached download is invalid and must be removed.
                 cache_f.close()
                 cached_file.unlink()
                 raise
@@ -97,13 +94,18 @@ def download_file_cached(
 def check_file_cached(
     url: str, cache: Optional[Path], cache_key: Optional[str]
 ) -> bool:
+    cached_file = cached_file_path(url, cache, cache_key)
+    return cached_file.is_file() or head_file(url)
+
+
+def cached_file_path(
+    url: str, cache: Optional[Path], cache_key: Optional[str]
+) -> Path:
     if not cache:
         cache = YUM_CACHE_DIR
     if cache_key:
         cache = cache / cache_key
-    cached_file = cache / url.split("/")[-1]
-    rv = cached_file.is_file() or head_file(url)
-    return rv
+    return cache / url.split("/")[-1]
 
 
 class TestKernel:
@@ -124,6 +126,8 @@ class TestKernel:
         pkgbase: str = "kernel-uek",
         yum_fmt: Optional[str] = None,
         frozen_release: Optional[str] = None,
+        skip_fetch: bool = False,
+        verbose: bool = True,
     ) -> None:
         self.ol_ver = ol_ver
         self.uek_ver = uek_ver
@@ -131,6 +135,8 @@ class TestKernel:
         self.pkgs = pkgs
         self.yum_fmt = yum_fmt
         self.pkgbase = pkgbase
+        self.skip_fetch = skip_fetch
+        self.verbose = verbose
 
         self._release: str = frozen_release or ""
         self._rpm_urls: List[str] = []
@@ -155,18 +161,44 @@ class TestKernel:
     def _cache_key(self, kind: str) -> str:
         return f"{self.slug()}/{kind}"
 
+    def _cached_path(self, kind: str, url: str) -> Path:
+        return cached_file_path(url, self.cache_dir, self._cache_key(kind))
+
+    def _cache_hit(self, kind: str, url: str) -> bool:
+        if self.skip_fetch:
+            return self._cached_path(kind, url).is_file()
+        return check_file_cached(url, self.cache_dir, self._cache_key(kind))
+
+    def _require_cached_file(self, kind: str, url: str) -> Path:
+        path = self._cached_path(kind, url)
+        if not path.is_file():
+            raise RuntimeError(
+                f"Cached file is missing for {self.slug()}: {path} "
+                "(disable skip_fetch)"
+            )
+        return path
+
+    def _get_repomd(self, index_url: str) -> Path:
+        if self.skip_fetch:
+            return self._require_cached_file("db", index_url)
+        return download_file_cached(
+            index_url,
+            quiet=not self.verbose,
+            desc="Fetching index",
+            cache=self.cache_dir,
+            cache_key=self._cache_key("db"),
+        )
+
     def _getlatest(self) -> None:
         # Fetch Yum index (repomd.xml) to get the database filename.
-        # This is never cached, and it's a small file.
         yumbase = (self.yum_fmt or UEK_YUM).format(
             ol_ver=self.ol_ver,
             uek_ver=self.uek_ver,
             arch=self.arch,
         )
         index_url = yumbase + REPODATA
-        xml = io.BytesIO()
-        download_file(index_url, xml, desc="Fetching index", quiet=False)
-        tree = ET.fromstring(xml.getvalue().decode("utf-8"))
+        repomd_path = self._get_repomd(index_url)
+        tree = ET.fromstring(repomd_path.read_text())
         ns = "http://linux.duke.edu/metadata/repo"
         primary_db_node = tree.findall(
             f".//{{{ns}}}data[@type='primary_db']/{{{ns}}}location"
@@ -174,16 +206,22 @@ class TestKernel:
 
         # Now fetch the database and decompress it if necessary
         db_url = yumbase + primary_db_node.attrib["href"]
-        db_path = download_file_cached(
-            db_url,
-            cache=self.cache_dir,
-            cache_key=self._cache_key("db"),
-            desc="Fetching primary_db",
-        )
+        if self.skip_fetch:
+            db_path = self._require_cached_file("db", db_url)
+        else:
+            db_path = download_file_cached(
+                db_url,
+                quiet=not self.verbose,
+                cache=self.cache_dir,
+                cache_key=self._cache_key("db"),
+                desc="Fetching primary_db",
+                delete_on_miss=False,
+            )
         if db_path.name.endswith(".bz2"):
             db_path_dec = db_path.parent / db_path.name[: -len(".bz2")]
             if not db_path_dec.is_file():
-                print("Decompressing primary_db")
+                if self.verbose:
+                    print("Decompressing primary_db")
                 subprocess.run(
                     ["bunzip2", "-k", "-q", str(db_path)], check=True
                 )
@@ -232,9 +270,7 @@ class TestKernel:
             release = f"{ver}-{rel}.{self.arch}"
             for final_pkg in self.pkgs:
                 url = rpm_url.replace(self.pkgbase, final_pkg)
-                if not check_file_cached(
-                    url, self.cache_dir, self._cache_key("rpm")
-                ):
+                if not self._cache_hit("rpm", url):
                     missing_urls.append(url)
                 rpm_urls.append(url)
             dbinfo_url = DEBUGINFO_URL.format(
@@ -242,9 +278,7 @@ class TestKernel:
                 release=release,
                 pkgbase=self.pkgbase,
             )
-            if not check_file_cached(
-                dbinfo_url, self.cache_dir, self._cache_key("rpm")
-            ):
+            if not self._cache_hit("rpm", dbinfo_url):
                 missing_urls.append(dbinfo_url)
 
             # If some RPMs are available, we have two options:
@@ -279,21 +313,29 @@ class TestKernel:
         self._rpm_paths = []
         try:
             for i, url in enumerate(self._rpm_urls):
+                if self.skip_fetch:
+                    path = self._require_cached_file("rpm", url)
+                else:
+                    path = download_file_cached(
+                        url,
+                        quiet=not self.verbose,
+                        desc=f"RPM {i + 1}/{len(self._rpm_urls)}",
+                        cache=self.cache_dir,
+                        cache_key=self._cache_key("rpm"),
+                        delete_on_miss=(i == 0),
+                    )
+                self._rpm_paths.append(path)
+            if self.skip_fetch:
+                path = self._require_cached_file("rpm", self._dbinfo_url)
+            else:
                 path = download_file_cached(
-                    url,
-                    desc=f"RPM {i + 1}/{len(self._rpm_urls)}",
+                    self._dbinfo_url,
+                    quiet=not self.verbose,
+                    desc="Debuginfo RPM",
                     cache=self.cache_dir,
                     cache_key=self._cache_key("rpm"),
-                    delete_on_miss=(i == 0),
+                    delete_on_miss=False,
                 )
-                self._rpm_paths.append(path)
-            path = download_file_cached(
-                self._dbinfo_url,
-                desc="Debuginfo RPM",
-                cache=self.cache_dir,
-                cache_key=self._cache_key("rpm"),
-                delete_on_miss=False,
-            )
         except HTTPError as e:
             sys.exit(
                 f"HTTP error {e.code} {e.reason} encountered while "

--- a/testing/litevm/vm.py
+++ b/testing/litevm/vm.py
@@ -292,6 +292,13 @@ def find_vmlinuz(release: str, root_dir: Path) -> Path:
     return root_dir / f"boot/vmlinuz-{release}"
 
 
+def find_qemu(arch: str) -> str:
+    if os.path.exists("/usr/libexec/qemu-kvm"):
+        return "/usr/libexec/qemu-kvm"
+    else:
+        return f"qemu-system-{arch}"
+
+
 def run_vm(kernel: TestKernel, extract_dir: Path, commands: List[List[str]]):
     release = kernel.latest_release()
     extract_dir = extract_dir / release
@@ -307,7 +314,7 @@ def run_vm(kernel: TestKernel, extract_dir: Path, commands: List[List[str]]):
     initrd = create_initrd(release, extract_dir, command=script)
     vmlinuz = find_vmlinuz(release, extract_dir)
     with create_block_image() as block_img_path, tempfile.NamedTemporaryFile() as tf:
-        qemu = f"qemu-system-{kernel.arch}"
+        qemu = find_qemu(kernel.arch)
         if os.access("/dev/kvm", os.R_OK | os.W_OK):
             args = [qemu, "-cpu", "host", "--enable-kvm"]
         else:

--- a/testing/vm/__init__.py
+++ b/testing/vm/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/

--- a/testing/vm/artifacts.py
+++ b/testing/vm/artifacts.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+"""Kernel RPM download/extract orchestration for testing.vm."""
+import os
+import shutil
+from pathlib import Path
+from typing import NamedTuple
+
+from testing.litevm.rpm import extract_rpms
+from testing.litevm.rpm import TestKernel
+
+
+class KernelArtifacts(NamedTuple):
+    release: str
+    extract_dir: Path
+
+
+def ensure_kernel_artifacts(
+    kernel: TestKernel,
+    extract_root: Path,
+    yum_cache_dir: Path,
+    skip_fetch: bool = False,
+) -> KernelArtifacts:
+    kernel.cache_dir = yum_cache_dir
+    release = kernel.latest_release()
+
+    out_dir = extract_root / release
+    if out_dir.is_dir():
+        return KernelArtifacts(release=release, extract_dir=out_dir)
+
+    building_dir = extract_root / f"{release}.building"
+    if building_dir.exists():
+        if building_dir.is_dir():
+            shutil.rmtree(building_dir)
+        else:
+            building_dir.unlink()
+
+    if skip_fetch:
+        raise RuntimeError(
+            f"Extracted kernel artifacts do not exist: {out_dir} "
+            "(disable --skip-rpm-fetch)"
+        )
+
+    extract_root.mkdir(parents=True, exist_ok=True)
+    try:
+        extract_rpms(kernel.get_rpms(), building_dir, kernel)
+        os.rename(building_dir, out_dir)
+    except BaseException:
+        shutil.rmtree(building_dir)
+        raise
+
+    return KernelArtifacts(release=release, extract_dir=out_dir)

--- a/testing/vm/artifacts.py
+++ b/testing/vm/artifacts.py
@@ -284,6 +284,7 @@ def ensure_kernel(
     """
     out_dir = layout.extract_path(kernel.release)
     if out_dir.is_dir():
+        log.already_done("Fetch & Extract Kernel RPMs", out_dir)
         return out_dir
 
     if skip_fetch:
@@ -306,5 +307,5 @@ def ensure_kernel(
         if building_dir.exists():
             shutil.rmtree(str(building_dir))
         raise
-    log.built("kernel RPMs extracted", out_dir)
+    log.done("Fetch & Extract Kernel RPMs", out_dir)
     return out_dir

--- a/testing/vm/artifacts.py
+++ b/testing/vm/artifacts.py
@@ -19,12 +19,16 @@ from testing.litevm.rpm import download_file_cached
 from testing.litevm.rpm import REPODATA
 from testing.litevm.rpm import UEK_YUM
 from testing.vm.config import KernelCategory
+from testing.vm.config import KernelKind
 from testing.vm.config import KernelVer
 from testing.vm.config import VmLayout
 from testing.vm.logging import VmLogger
 
 
-UEKNEXT_YUM = "https://yum.oracle.com/repo/OracleLinux/OL{ol_ver}/developer/UEK{uek_ver}/{arch}/"
+UEKNEXT_YUM = "https://yum.oracle.com/repo/OracleLinux/OL{ol_ver}/developer/UEKNEXT/{arch}/"
+RHCK_YUM = (
+    "https://yum.oracle.com/repo/OracleLinux/OL{ol_ver}/baseos/latest/{arch}/"
+)
 
 
 def _cache_key(category: KernelCategory, kind: str) -> str:
@@ -50,12 +54,15 @@ def _require_cached_file(
 
 
 def _yum_base(category: KernelCategory) -> str:
-    fmt = UEKNEXT_YUM if category.uek_ver == "next" else UEK_YUM
-    return fmt.format(
-        ol_ver=category.ol_ver,
-        uek_ver=category.uek_ver,
-        arch=category.arch,
-    )
+    fmtdict = category._asdict()
+    if category.kind == KernelKind.UEKNEXT:
+        fmt = UEKNEXT_YUM
+    elif category.kind == KernelKind.RHCK:
+        fmt = RHCK_YUM
+    else:
+        fmt = UEK_YUM
+        fmtdict["uek_ver"] = category.uek_ver
+    return fmt.format_map(fmtdict)
 
 
 def _fetch_repomd(
@@ -129,7 +136,21 @@ def _resolve_urls(
     base_url = _yum_base(category) + href
     urls = []
     for pkg in category.rpms():
-        urls.append(_rpm_url(base_url, category.rpmbase, pkg))
+        if (
+            pkg.startswith("kernel-devel")
+            and category.kind == KernelKind.RHCK
+            and category.ol_ver >= 9
+        ):
+            # RHCK put kernel-devel in appstream from OL9
+            urls.append(
+                _rpm_url(
+                    base_url.replace("baseos/latest", "appstream"),
+                    category.rpmbase,
+                    pkg,
+                )
+            )
+        else:
+            urls.append(_rpm_url(base_url, category.rpmbase, pkg))
     dbinfo_url = DEBUGINFO_URL.format(
         ol_ver=category.ol_ver,
         release=release,

--- a/testing/vm/artifacts.py
+++ b/testing/vm/artifacts.py
@@ -307,6 +307,7 @@ def ensure_kernel(
     if out_dir.is_dir():
         log.already_done("Fetch & Extract Kernel RPMs", out_dir)
         return out_dir
+    log.working("Fetch & Extract Kernel RPMs", out_dir)
 
     if skip_fetch:
         rpm_paths = _cached_kernel_rpms(kernel, layout)

--- a/testing/vm/artifacts.py
+++ b/testing/vm/artifacts.py
@@ -25,7 +25,7 @@ from testing.vm.config import VmLayout
 from testing.vm.logging import VmLogger
 
 
-UEKNEXT_YUM = "https://yum.oracle.com/repo/OracleLinux/OL{ol_ver}/developer/UEKNEXT/{arch}/"
+UEKNEXT_YUM = "https://yum.oracle.com/repo/OracleLinux/OL{ol_ver}/developer/UEKnext/{arch}/"
 RHCK_YUM = (
     "https://yum.oracle.com/repo/OracleLinux/OL{ol_ver}/baseos/latest/{arch}/"
 )

--- a/testing/vm/artifacts.py
+++ b/testing/vm/artifacts.py
@@ -1,52 +1,310 @@
 # Copyright (c) 2026, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
-"""Kernel RPM download/extract orchestration for testing.vm."""
+"""Kernel RPM resolution/download/extract orchestration for testing.vm."""
 import os
+import shlex
 import shutil
+import sqlite3
+import subprocess
+import xml.etree.ElementTree as ET
 from pathlib import Path
-from typing import NamedTuple
+from typing import List
+from urllib.error import HTTPError
 
-from testing.litevm.rpm import extract_rpms
-from testing.litevm.rpm import TestKernel
+from drgn_tools.util import head_file
+from testing.litevm.rpm import cached_file_path
+from testing.litevm.rpm import check_file_cached
+from testing.litevm.rpm import DEBUGINFO_URL
+from testing.litevm.rpm import download_file_cached
+from testing.litevm.rpm import REPODATA
+from testing.litevm.rpm import UEK_YUM
+from testing.vm.config import KernelCategory
+from testing.vm.config import KernelVer
+from testing.vm.config import VmLayout
+from testing.vm.logging import VmLogger
 
 
-class KernelArtifacts(NamedTuple):
-    release: str
-    extract_dir: Path
+UEKNEXT_YUM = "https://yum.oracle.com/repo/OracleLinux/OL{ol_ver}/developer/UEK{uek_ver}/{arch}/"
 
 
-def ensure_kernel_artifacts(
-    kernel: TestKernel,
-    extract_root: Path,
-    yum_cache_dir: Path,
+def _cache_key(category: KernelCategory, kind: str) -> str:
+    return "{}/{}".format(category.slug, kind)
+
+
+def _require_cached_file(
+    category: KernelCategory,
+    kind: str,
+    url: str,
+    layout: VmLayout,
+) -> Path:
+    path = cached_file_path(
+        url, layout.yum_cache_dir, _cache_key(category, kind)
+    )
+    if not path.is_file():
+        raise RuntimeError(
+            "Cached file is missing for {}: {} (disable --skip-rpm-fetch)".format(
+                category.slug, path
+            )
+        )
+    return path
+
+
+def _yum_base(category: KernelCategory) -> str:
+    fmt = UEKNEXT_YUM if category.uek_ver == "next" else UEK_YUM
+    return fmt.format(
+        ol_ver=category.ol_ver,
+        uek_ver=category.uek_ver,
+        arch=category.arch,
+    )
+
+
+def _fetch_repomd(
+    category: KernelCategory,
+    layout: VmLayout,
+    skip_fetch: bool,
+    verbose: bool,
+) -> Path:
+    index_url = _yum_base(category) + REPODATA
+    if skip_fetch:
+        return _require_cached_file(category, "db", index_url, layout)
+    return download_file_cached(
+        index_url,
+        quiet=not verbose,
+        desc="Fetching index",
+        cache=layout.yum_cache_dir,
+        cache_key=_cache_key(category, "db"),
+    )
+
+
+def _fetch_primary_db(
+    category: KernelCategory,
+    layout: VmLayout,
+    skip_fetch: bool,
+    verbose: bool,
+) -> Path:
+    repomd = ET.fromstring(
+        _fetch_repomd(category, layout, skip_fetch, verbose).read_text()
+    )
+    ns = "http://linux.duke.edu/metadata/repo"
+    primary_db_node = repomd.findall(
+        ".//{{{}}}data[@type='primary_db']/{{{}}}location".format(ns, ns)
+    )[0]
+    db_url = _yum_base(category) + primary_db_node.attrib["href"]
+    if skip_fetch:
+        db_path = _require_cached_file(category, "db", db_url, layout)
+    else:
+        db_path = download_file_cached(
+            db_url,
+            quiet=not verbose,
+            cache=layout.yum_cache_dir,
+            cache_key=_cache_key(category, "db"),
+            desc="Fetching primary_db",
+            delete_on_miss=False,
+        )
+    if db_path.name.endswith(".bz2"):
+        db_path_dec = db_path.parent / db_path.name[: -len(".bz2")]
+        if not db_path_dec.is_file():
+            if verbose:
+                print("Decompressing primary_db")
+            subprocess.run(["bunzip2", "-k", "-q", str(db_path)], check=True)
+        db_path = db_path_dec
+    return db_path
+
+
+def _version_sort_key(row: tuple) -> tuple:
+    return tuple(map(int, row[0].split(".") + row[1].split(".")[:-1]))
+
+
+def _rpm_url(base_url: str, pkgbase: str, pkgname: str) -> str:
+    return base_url.replace(pkgbase, pkgname)
+
+
+def _resolve_urls(
+    category: KernelCategory,
+    release: str,
+    href: str,
+    layout: VmLayout,
+    skip_fetch: bool,
+) -> List[str]:
+    base_url = _yum_base(category) + href
+    urls = []
+    for pkg in category.rpms():
+        urls.append(_rpm_url(base_url, category.rpmbase, pkg))
+    dbinfo_url = DEBUGINFO_URL.format(
+        ol_ver=category.ol_ver,
+        release=release,
+        pkgbase=category.rpmbase,
+    )
+    urls.append(dbinfo_url)
+
+    if skip_fetch:
+        # In skip_fetch mode, verify the files are downloaded
+        for url in urls:
+            _require_cached_file(category, "rpm", url, layout)
+    else:
+        # Otherwise, ensure that the files are either downloaded or
+        # at least present on the repo. If not present, we can fall back to an
+        # older version according to palicy.
+        key = _cache_key(category, "rpm")
+        for url in urls:
+            if not (
+                check_file_cached(url, layout.yum_cache_dir, key)
+                or head_file(url)
+            ):
+                return []
+    return urls
+
+
+def resolve_kernel(
+    category: KernelCategory,
+    paths: VmLayout,
+    log: VmLogger,
     skip_fetch: bool = False,
-) -> KernelArtifacts:
-    kernel.cache_dir = yum_cache_dir
-    release = kernel.latest_release()
+) -> KernelVer:
+    """
+    Given a kernel category, determine the latest available version
 
-    out_dir = extract_root / release
+    :param category: OL + UEK version to download
+    :param paths: pointer to data directory
+    :param log: logger for tasks
+    :param skip_fetch: if set, we will avoid fetching anything from the network,
+      but all the data should already be present and cached locally
+    """
+    db_path = _fetch_primary_db(category, paths, skip_fetch, log.verbose)
+    conn = sqlite3.connect(str(db_path))
+    rows = conn.execute(
+        """
+        SELECT version, release, location_href FROM packages
+        WHERE name=? AND arch=?;
+        """,
+        (category.rpmbase, category.arch),
+    ).fetchall()
+    conn.close()
+
+    allow_missing = bool(
+        int(os.environ.get("DRGN_TOOLS_ALLOW_MISSING_LATEST", 0))
+    )
+    rows.sort(key=_version_sort_key, reverse=True)
+    versions_tried = []
+    for ver, rel, href in rows[:5]:
+        release = "{}-{}.{}".format(ver, rel, category.arch)
+        urls = _resolve_urls(category, release, href, paths, skip_fetch)
+        if urls:
+            return KernelVer(category, release, urls)
+        if allow_missing:
+            versions_tried.append(release)
+            if log.verbose:
+                print(
+                    "warning: {} had missing RPMs\nTrying an older release...".format(
+                        release
+                    )
+                )
+            continue
+        raise RuntimeError(
+            "Required RPMs were unavailable for {} ({})".format(
+                category.slug, release
+            )
+        )
+    raise RuntimeError(
+        "No release had all files available. Tried: {}".format(
+            ", ".join(versions_tried)
+        )
+    )
+
+
+def _download_kernel_rpms(
+    kernel: KernelVer,
+    layout: VmLayout,
+    log: VmLogger,
+) -> List[Path]:
+    paths = []
+    try:
+        for i, url in enumerate(kernel.urls):
+            desc = (
+                "Debuginfo RPM"
+                if i == len(kernel.urls) - 1
+                else "RPM {}/{}".format(i + 1, len(kernel.urls) - 1)
+            )
+            path = download_file_cached(
+                url,
+                quiet=not log.verbose,
+                desc=desc,
+                cache=layout.yum_cache_dir,
+                cache_key=_cache_key(kernel.category, "rpm"),
+                delete_on_miss=(i == 0),
+            )
+            paths.append(path)
+    except HTTPError as e:
+        raise RuntimeError(
+            "HTTP error {} {} encountered while fetching URL:\n{}".format(
+                e.code, e.reason, e.url
+            )
+        )
+    return paths
+
+
+def _cached_kernel_rpms(kernel: KernelVer, layout: VmLayout) -> List[Path]:
+    return [
+        _require_cached_file(kernel.category, "rpm", url, layout)
+        for url in kernel.urls
+    ]
+
+
+def _extract_rpms(paths: List[Path], kernel: KernelVer, out_dir: Path) -> None:
+    out_dir.mkdir(parents=True, exist_ok=False)
+    try:
+        out_dir_str = shlex.quote(str(out_dir))
+        for path in paths:
+            path_str = shlex.quote(str(path))
+            subprocess.run(
+                "rpm2cpio {} | cpio -id -D {} --quiet".format(
+                    path_str, out_dir_str
+                ),
+                shell=True,
+                check=True,
+            )
+        subprocess.run(
+            ["depmod", "-b", str(out_dir), kernel.release],
+            shell=False,
+            check=True,
+        )
+    except BaseException:
+        shutil.rmtree(str(out_dir))
+        raise
+
+
+def ensure_kernel(
+    kernel: KernelVer,
+    layout: VmLayout,
+    log: VmLogger,
+    skip_fetch: bool = False,
+) -> Path:
+    """
+    Given a kernel version, ensure it's downloaded and extracted
+    """
+    out_dir = layout.extract_path(kernel.release)
     if out_dir.is_dir():
-        return KernelArtifacts(release=release, extract_dir=out_dir)
+        return out_dir
 
-    building_dir = extract_root / f"{release}.building"
+    if skip_fetch:
+        rpm_paths = _cached_kernel_rpms(kernel, layout)
+    else:
+        rpm_paths = _download_kernel_rpms(kernel, layout, log)
+
+    building_dir = layout.extract_dir / "{}.building".format(kernel.release)
     if building_dir.exists():
         if building_dir.is_dir():
-            shutil.rmtree(building_dir)
+            shutil.rmtree(str(building_dir))
         else:
             building_dir.unlink()
 
-    if skip_fetch:
-        raise RuntimeError(
-            f"Extracted kernel artifacts do not exist: {out_dir} "
-            "(disable --skip-rpm-fetch)"
-        )
-
-    extract_root.mkdir(parents=True, exist_ok=True)
+    layout.extract_dir.mkdir(parents=True, exist_ok=True)
     try:
-        extract_rpms(kernel.get_rpms(), building_dir, kernel)
-        os.rename(building_dir, out_dir)
+        _extract_rpms(rpm_paths, kernel, building_dir)
+        os.rename(str(building_dir), str(out_dir))
     except BaseException:
-        shutil.rmtree(building_dir)
+        if building_dir.exists():
+            shutil.rmtree(str(building_dir))
         raise
-
-    return KernelArtifacts(release=release, extract_dir=out_dir)
+    log.built("kernel RPMs extracted", out_dir)
+    return out_dir

--- a/testing/vm/boot.py
+++ b/testing/vm/boot.py
@@ -120,7 +120,7 @@ def _initrd_modules(shared_fs: str) -> List[str]:
 def _host_mount_command(shared_fs: str) -> str:
     _validate_shared_fs(shared_fs)
     if shared_fs == SHARED_FS_VIRTIOFS:
-        return "mount -t virtiofs hostfs /host"
+        return "mount -t virtiofs -o ro hostfs /host"
     return (
         "mount -t 9p "
         "-o ro,trans=virtio,cache=loose,msize=1048576 "
@@ -451,7 +451,6 @@ def _start_virtiofsd(socket_path: Path, shared_dir: Path) -> Iterator[None]:
             str(socket_path),
             "--shared-dir",
             str(shared_dir),
-            "--readonly",
             "--sandbox=none",
             "--cache=auto",
         ],

--- a/testing/vm/boot.py
+++ b/testing/vm/boot.py
@@ -65,7 +65,7 @@ set -eu
 result=FAIL
 cleanup() {{
     echo DRGN_VMTEST: $result
-    poweroff -f
+    echo b >/proc/sysrq-trigger
 }}
 trap cleanup EXIT
 
@@ -92,9 +92,8 @@ mount --bind /host /tmp/root/host
 
 {pre_chroot_setup}
 
-echo 'drgntools-test' >/tmp/root/etc/hostname
-chroot /tmp/root setsid -c /bin/sh -lc {guest_command}
-result=PASS
+hostname {hostname}
+exec switch_root /tmp/root /usr/bin/setsid -c /bin/sh -lc {guest_command}
 """
 
 
@@ -274,6 +273,8 @@ def _create_guest_command(
 
     lines = [
         "set -euo pipefail",
+        'cleanup() { [ "$?" -eq 0 ] && echo "DRGN_VMTEST: PASS" || echo "DRGN_VMTEST: FAIL" ; sleep 0.1; echo b >/proc/sysrq-trigger; }',
+        "trap cleanup EXIT",
         "export PATH=/sbin:/usr/sbin:/bin:/usr/bin",
         "export DRGNTOOLS_BLOCK_TEST_DIR=/mnt",
         f"cd {shlex.quote(repo_guest)}",
@@ -313,11 +314,18 @@ def _create_pre_chroot_setup(
     if kmod_path is not None:
         kmod_guest = _guest_path(kmod_path, shared_dir)
         lines.insert(-3, f"insmod {shlex.quote(kmod_guest)}")
+
+    terminal_size = shutil.get_terminal_size((0, 0))
+    if terminal_size.columns or terminal_size.lines:
+        lines.append(
+            f"stty cols {terminal_size.columns} rows {terminal_size.lines}"
+        )
+
     return "\n".join(lines)
 
 
 def _create_initrd(
-    release: str,
+    kernel: KernelVer,
     extract_dir: Path,
     rootfs_dir: Path,
     shared_dir: Path,
@@ -334,7 +342,7 @@ def _create_initrd(
             (td / path).mkdir(parents=True, exist_ok=True)
 
         initrd_modules = _copy_initrd_modules(
-            release, extract_dir, td, shared_fs
+            kernel.release, extract_dir, td, shared_fs
         )
 
         busybox_path = _require_tool("busybox")
@@ -347,7 +355,7 @@ def _create_initrd(
 
         module_load = "\n".join(
             "insmod {} || true".format(
-                shlex.quote(f"/lib/modules/{release}/{mod_path}")
+                shlex.quote(f"/lib/modules/{kernel.release}/{mod_path}")
             )
             for mod_path in initrd_modules
         )
@@ -355,6 +363,7 @@ def _create_initrd(
         init = td / "init"
         init.write_text(
             INIT_SCRIPT.format(
+                hostname=kernel.category.name,
                 module_load=module_load,
                 mount_host=_host_mount_command(shared_fs),
                 rootfs_host_path=shlex.quote(
@@ -366,7 +375,9 @@ def _create_initrd(
         )
         init.chmod(0o755)
 
-        out_path = extract_dir / "boot" / f"drgn-tools-initramfs-{release}.img"
+        out_path = (
+            extract_dir / "boot" / f"drgn-tools-initramfs-{kernel.release}.img"
+        )
         out_path.parent.mkdir(parents=True, exist_ok=True)
         with out_path.open("wb") as f:
             subprocess.run(
@@ -527,12 +538,11 @@ def run_in_vm(
     kmod_path: Optional[Path] = None,
     shared_fs: Optional[str] = None,
 ) -> None:
-    release = kernel.release
     if shared_fs is None:
         shared_fs = kernel.category.shared_fs
     _validate_shared_fs(shared_fs)
 
-    extract_dir = layout.extract_path(release)
+    extract_dir = layout.extract_path(kernel.release)
     qemu = _find_qemu(kernel.category.arch)
 
     repo_root = repo_root.absolute()
@@ -564,13 +574,13 @@ def run_in_vm(
         command,
     )
     pre_chroot_setup = _create_pre_chroot_setup(
-        release,
+        kernel.release,
         extract_dir,
         kmod_path,
         shared_dir,
     )
     initrd = _create_initrd(
-        release,
+        kernel,
         extract_dir,
         rootfs_dir,
         shared_dir,
@@ -578,7 +588,7 @@ def run_in_vm(
         guest_command,
         shared_fs,
     )
-    vmlinuz = _find_vmlinuz(release, extract_dir)
+    vmlinuz = _find_vmlinuz(kernel.release, extract_dir)
 
     if log_path is not None:
         log_path.parent.mkdir(parents=True, exist_ok=True)
@@ -602,7 +612,7 @@ def run_in_vm(
         else:
             serial_args = ["-serial", "stdio", "-monitor", "none"]
 
-        kernel_cmdline = "console=ttyS0 panic=-1"
+        kernel_cmdline = "console=ttyS0,115200 panic=-1"
         if not log.verbose:
             kernel_cmdline = "quiet loglevel=1 " + kernel_cmdline
 

--- a/testing/vm/boot.py
+++ b/testing/vm/boot.py
@@ -609,7 +609,7 @@ def run_in_vm(
         if log_path:
             serial_args = ["-serial", "stdio", "-monitor", "none"]
         else:
-            serial_args = ["-serial", "stdio", "-monitor", "none"]
+            serial_args = ["-serial", "mon:stdio"]
 
         kernel_cmdline = "console=ttyS0,115200 panic=-1"
         if not log.verbose:
@@ -618,7 +618,6 @@ def run_in_vm(
         args += [
             # fmt: off
             "-display", "none",
-            "-nodefaults",
             "-no-reboot",
 
             "-kernel", str(vmlinuz),

--- a/testing/vm/boot.py
+++ b/testing/vm/boot.py
@@ -1,0 +1,649 @@
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+"""VM boot and in-guest command execution for testing.vm."""
+import bz2
+import contextlib
+import gzip
+import lzma
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Dict
+from typing import Iterable
+from typing import Iterator
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+from testing.vm.config import KernelVer
+from testing.vm.config import SHARED_FS_VIRTIOFS
+from testing.vm.config import SUPPORTED_SHARED_FS
+from testing.vm.config import VmLayout
+from testing.vm.logging import VmLogger
+
+
+INITRD_DIRS = [
+    "bin",
+    "dev",
+    "etc",
+    "lib/modules",
+    "proc",
+    "sys",
+    "tmp",
+    "usr/bin",
+    "usr/sbin",
+]
+
+# Keep this list intentionally small and let dependency expansion add the rest.
+COMMON_INITRD_MODULES = [
+    "overlay",
+    "virtio_pci",
+    "virtio_blk",
+    "ext4",
+]
+
+VIRTIOFS_INITRD_MODULES = [
+    "virtiofs",
+    "fuse",
+]
+
+NINEP_INITRD_MODULES = [
+    "9p",
+    "9pnet_virtio",
+]
+
+
+INIT_SCRIPT = """#!/bin/sh
+set -eu
+
+result=FAIL
+cleanup() {{
+    echo DRGN_VMTEST: $result
+    poweroff -f
+}}
+trap cleanup EXIT
+
+mount -t proc proc /proc
+mount -t sysfs sys /sys
+mount -t devtmpfs dev /dev
+mount -t tmpfs tmpfs /tmp
+
+{module_load}
+
+mkdir -p /host
+{mount_host}
+
+mkdir -p /tmp/upper /tmp/work /tmp/root
+mount -t overlay overlay \\
+      -o lowerdir={rootfs_host_path},upperdir=/tmp/upper,workdir=/tmp/work \\
+      /tmp/root
+
+mkdir -p /tmp/root/proc /tmp/root/sys /tmp/root/dev /tmp/root/host
+mount -t proc proc /tmp/root/proc
+mount -t sysfs sys /tmp/root/sys
+mount -t devtmpfs dev /tmp/root/dev
+mount --bind /host /tmp/root/host
+
+{pre_chroot_setup}
+
+echo 'drgntools-test' >/tmp/root/etc/hostname
+chroot /tmp/root setsid -c /bin/sh -lc {guest_command}
+result=PASS
+"""
+
+
+def _validate_shared_fs(shared_fs: str) -> None:
+    if shared_fs not in SUPPORTED_SHARED_FS:
+        raise RuntimeError(
+            "Unsupported shared filesystem {!r}; expected one of {}".format(
+                shared_fs,
+                ", ".join(SUPPORTED_SHARED_FS),
+            )
+        )
+
+
+def _initrd_modules(shared_fs: str) -> List[str]:
+    _validate_shared_fs(shared_fs)
+    modules = list(COMMON_INITRD_MODULES)
+    if shared_fs == SHARED_FS_VIRTIOFS:
+        modules.extend(VIRTIOFS_INITRD_MODULES)
+    else:
+        modules.extend(NINEP_INITRD_MODULES)
+    return modules
+
+
+def _host_mount_command(shared_fs: str) -> str:
+    _validate_shared_fs(shared_fs)
+    if shared_fs == SHARED_FS_VIRTIOFS:
+        return "mount -t virtiofs hostfs /host"
+    return (
+        "mount -t 9p "
+        "-o ro,trans=virtio,cache=loose,msize=1048576 "
+        "hostfs /host"
+    )
+
+
+def _guest_path(path: Path, shared_dir: Path) -> str:
+    rel = path.absolute().relative_to(shared_dir)
+    return "/host/" + str(rel)
+
+
+def _find_qemu(arch: str) -> str:
+    if os.path.exists("/usr/libexec/qemu-kvm"):
+        return "/usr/libexec/qemu-kvm"
+    name = f"qemu-system-{arch}"
+    path = shutil.which(name)
+    if path:
+        return path
+    raise RuntimeError(f"Unable to locate qemu executable: {name}")
+
+
+def _find_virtiofsd() -> str:
+    for path in (
+        shutil.which("virtiofsd"),
+        "/usr/libexec/virtiofsd",
+        "/usr/lib/qemu/virtiofsd",
+    ):
+        if path and os.path.exists(path):
+            return path
+    raise RuntimeError("Unable to locate virtiofsd executable")
+
+
+def _require_tool(name: str) -> str:
+    path = shutil.which(name)
+    if not path:
+        raise RuntimeError(f"Required tool is missing: {name}")
+    return path
+
+
+def _topological_sort(
+    graph: Dict[str, List[str]],
+    start: Optional[Iterable[str]] = None,
+) -> List[str]:
+    order = []
+    seen = set()
+
+    def rec(node: str) -> None:
+        if node in seen:
+            return
+        seen.add(node)
+        for desc in graph[node]:
+            rec(desc)
+        order.append(node)
+
+    if not start:
+        start = graph.keys()
+
+    for node in start:
+        rec(node)
+    return order
+
+
+def _read_modules_dep(path: Path) -> Dict[str, List[str]]:
+    modules_dep = {}
+    with path.open() as f:
+        for line in f:
+            key, value = line.split(":", 1)
+            modules_dep[key.strip()] = value.split()
+    return modules_dep
+
+
+def _module_name(path: str) -> str:
+    return path.split("/")[-1].split(".")[0]
+
+
+def _decompress_zstd(src_file: Path) -> bytes:
+    zstd = shutil.which("zstd")
+    if not zstd:
+        raise RuntimeError(
+            "Kernel module is compressed with zstd but `zstd` was not "
+            f"found: {src_file}"
+        )
+    result = subprocess.run(
+        [zstd, "-d", "-q", "-c", str(src_file)],
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    return result.stdout
+
+
+def _read_module_payload(src_file: Path, rel_path: str) -> Tuple[str, bytes]:
+    if rel_path.endswith(".ko.xz"):
+        return rel_path[:-3], lzma.decompress(src_file.read_bytes())
+    if rel_path.endswith(".ko.gz"):
+        return rel_path[:-3], gzip.decompress(src_file.read_bytes())
+    if rel_path.endswith(".ko.bz2"):
+        return rel_path[:-4], bz2.decompress(src_file.read_bytes())
+    if rel_path.endswith(".ko.zst"):
+        return rel_path[:-4], _decompress_zstd(src_file)
+    return rel_path, src_file.read_bytes()
+
+
+def _copy_initrd_modules(
+    release: str, extract_dir: Path, initrd_dir: Path, shared_fs: str
+) -> List[str]:
+    initrd_mod_dir = initrd_dir / "lib/modules" / release
+    root_mod_dir = extract_dir / "lib/modules" / release
+
+    all_modules = _read_modules_dep(root_mod_dir / "modules.dep")
+    name_to_path = {_module_name(mod): mod for mod in all_modules.keys()}
+    requested = [
+        name_to_path[m]
+        for m in _initrd_modules(shared_fs)
+        if m in name_to_path
+    ]
+    needed_paths = _topological_sort(all_modules, requested)
+
+    load_paths = []
+    initrd_mod_dir.mkdir(parents=True, exist_ok=True)
+    for mod_path in needed_paths:
+        src = root_mod_dir / mod_path
+        out_rel_path, payload = _read_module_payload(src, mod_path)
+        dst = initrd_mod_dir / out_rel_path
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        dst.write_bytes(payload)
+        load_paths.append(out_rel_path)
+
+    return load_paths
+
+
+def _find_vmlinuz(release: str, extract_dir: Path) -> Path:
+    path_in_modules = extract_dir / "lib/modules" / release / "vmlinuz"
+    if path_in_modules.is_file():
+        return path_in_modules
+    path_in_boot = extract_dir / "boot" / f"vmlinuz-{release}"
+    if path_in_boot.is_file():
+        return path_in_boot
+    raise RuntimeError(f"Unable to locate vmlinuz for release {release}")
+
+
+def _create_guest_command(
+    repo_root: Path,
+    kmod_path: Optional[Path],
+    shared_dir: Path,
+    command: List[str],
+) -> str:
+    cmd = " ".join(shlex.quote(arg) for arg in command)
+    repo_guest = _guest_path(repo_root, shared_dir)
+
+    lines = [
+        "set -euo pipefail",
+        "export PATH=/sbin:/usr/sbin:/bin:/usr/bin",
+        "export DRGNTOOLS_BLOCK_TEST_DIR=/mnt",
+        f"cd {shlex.quote(repo_guest)}",
+    ]
+    if kmod_path is not None:
+        kmod_guest = _guest_path(kmod_path, shared_dir)
+        lines.append(f"export DRGNTOOLS_TEST_KMOD={shlex.quote(kmod_guest)}")
+    lines.append(cmd)
+    return " ; ".join(lines)
+
+
+def _create_pre_chroot_setup(
+    release: str,
+    extract_dir: Path,
+    kmod_path: Optional[Path],
+    shared_dir: Path,
+) -> str:
+    extract_guest = _guest_path(extract_dir, shared_dir)
+    mod_src = f"{extract_guest}/lib/modules/{release}"
+    dbg_src = f"{extract_guest}/usr/lib/debug/lib/modules/{release}"
+
+    lines = [
+        f"mkdir -p /tmp/root/lib/modules/{release}",
+        (
+            f"mount --bind {shlex.quote(mod_src)} "
+            f"/tmp/root/lib/modules/{release}"
+        ),
+        f"mkdir -p /tmp/root/usr/lib/debug/lib/modules/{release}",
+        (
+            f"mount --bind {shlex.quote(dbg_src)} "
+            f"/tmp/root/usr/lib/debug/lib/modules/{release}"
+        ),
+        "mke2fs -F /dev/vda >/dev/null",
+        "mkdir -p /tmp/root/mnt",
+        "mount /dev/vda /tmp/root/mnt",
+    ]
+    if kmod_path is not None:
+        kmod_guest = _guest_path(kmod_path, shared_dir)
+        lines.insert(-3, f"insmod {shlex.quote(kmod_guest)}")
+    return "\n".join(lines)
+
+
+def _create_initrd(
+    release: str,
+    extract_dir: Path,
+    rootfs_dir: Path,
+    shared_dir: Path,
+    pre_chroot_setup: str,
+    guest_command: str,
+    shared_fs: str,
+) -> Path:
+    _require_tool("cpio")
+    _require_tool("gzip")
+
+    with TemporaryDirectory() as tempdir:
+        td = Path(tempdir)
+        for path in INITRD_DIRS:
+            (td / path).mkdir(parents=True, exist_ok=True)
+
+        initrd_modules = _copy_initrd_modules(
+            release, extract_dir, td, shared_fs
+        )
+
+        busybox_path = _require_tool("busybox")
+        busybox = td / "bin/busybox"
+        shutil.copy(busybox_path, busybox)
+        subprocess.run(
+            [str(busybox), "--install", str(td / "bin")],
+            check=True,
+        )
+
+        module_load = "\n".join(
+            "insmod {} || true".format(
+                shlex.quote(f"/lib/modules/{release}/{mod_path}")
+            )
+            for mod_path in initrd_modules
+        )
+
+        init = td / "init"
+        init.write_text(
+            INIT_SCRIPT.format(
+                module_load=module_load,
+                mount_host=_host_mount_command(shared_fs),
+                rootfs_host_path=shlex.quote(
+                    _guest_path(rootfs_dir, shared_dir)
+                ),
+                pre_chroot_setup=pre_chroot_setup,
+                guest_command=shlex.quote(guest_command),
+            )
+        )
+        init.chmod(0o755)
+
+        out_path = extract_dir / "boot" / f"drgn-tools-initramfs-{release}.img"
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with out_path.open("wb") as f:
+            subprocess.run(
+                "find . -print0 "
+                "| cpio --null --format=newc --create --quiet "
+                "| gzip --best --no-name",
+                cwd=td,
+                check=True,
+                shell=True,
+                stdout=f,
+            )
+        return out_path
+
+
+def _run_qemu(
+    args: List[str],
+    log_path: Optional[Path],
+    verbose: bool,
+    stdin: Optional[int],
+) -> int:
+    if log_path is None:
+        result = subprocess.run(
+            args,
+            check=False,
+            stdin=stdin,
+        )
+        return result.returncode
+
+    if not verbose:
+        with log_path.open("wb") as f:
+            result = subprocess.run(
+                args,
+                check=False,
+                stdout=f,
+                stderr=f,
+                stdin=stdin,
+            )
+        return result.returncode
+
+    with log_path.open("wb") as log_file:
+        proc = subprocess.Popen(
+            args,
+            stdin=stdin,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        assert proc.stdout is not None
+        for chunk in iter(lambda: proc.stdout.read(4096), b""):  # type: ignore
+            log_file.write(chunk)
+            sys.stdout.buffer.write(chunk)
+            sys.stdout.buffer.flush()
+        return proc.wait()
+
+
+@contextlib.contextmanager
+def _create_block_image(size_mb: int = 400) -> Iterator[Path]:
+    with TemporaryDirectory() as tempdir:
+        img = Path(tempdir) / "disk.img"
+        with img.open("wb") as f:
+            f.truncate(size_mb * 1024 * 1024)
+        yield img
+
+
+@contextlib.contextmanager
+def _start_virtiofsd(socket_path: Path, shared_dir: Path) -> Iterator[None]:
+    virtiofsd = _find_virtiofsd()
+    proc = subprocess.Popen(
+        [
+            virtiofsd,
+            "--socket-path",
+            str(socket_path),
+            "--shared-dir",
+            str(shared_dir),
+            "--readonly",
+            "--sandbox=none",
+            "--cache=auto",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,  # text=True for 3.7+
+    )
+    try:
+        # The socket appears almost immediately; keep the check simple.
+        for _ in range(100):
+            if socket_path.exists():
+                break
+            if proc.poll() is not None:
+                stderr = proc.stderr.read() if proc.stderr else ""
+                msg = stderr.strip() or "no stderr"
+                raise RuntimeError(f"virtiofsd exited unexpectedly: {msg}")
+            time.sleep(0.02)
+        else:
+            raise RuntimeError("virtiofsd socket was not created")
+        yield
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=2)
+
+
+def _qemu_memory_args(shared_fs: str) -> List[str]:
+    _validate_shared_fs(shared_fs)
+    if shared_fs == SHARED_FS_VIRTIOFS:
+        return [
+            # memfd backend is necessary for virtiofsd.
+            "-object",
+            "memory-backend-memfd,id=mem,size=2048M,share=on",
+            "-machine",
+            "q35,memory-backend=mem",
+            "-m",
+            "2048",
+        ]
+    return [
+        "-machine",
+        "q35",
+        "-m",
+        "2048",
+    ]
+
+
+def _qemu_host_share_args(
+    shared_fs: str,
+    shared_dir: Path,
+    socket_path: Optional[Path],
+) -> List[str]:
+    _validate_shared_fs(shared_fs)
+    if shared_fs == SHARED_FS_VIRTIOFS:
+        if socket_path is None:
+            raise RuntimeError("virtiofs requires a virtiofsd socket path")
+        return [
+            "-device",
+            "vhost-user-fs-pci,chardev=char0,tag=hostfs",
+            "-chardev",
+            f"socket,id=char0,path={socket_path}",
+        ]
+    return [
+        "-fsdev",
+        (
+            f"local,id=hostfs,path={shared_dir},security_model=none,"
+            "readonly=on,multidevs=remap"
+        ),
+        "-device",
+        "virtio-9p-pci,fsdev=hostfs,mount_tag=hostfs",
+    ]
+
+
+def run_in_vm(
+    kernel: KernelVer,
+    rootfs_dir: Path,
+    layout: VmLayout,
+    repo_root: Path,
+    command: List[str],
+    log_path: Optional[Path],
+    log: VmLogger,
+    kmod_path: Optional[Path] = None,
+    shared_fs: Optional[str] = None,
+) -> None:
+    release = kernel.release
+    if shared_fs is None:
+        shared_fs = kernel.category.shared_fs
+    _validate_shared_fs(shared_fs)
+
+    extract_dir = layout.extract_path(release)
+    qemu = _find_qemu(kernel.category.arch)
+
+    repo_root = repo_root.absolute()
+    base_dir = layout.base_dir.absolute()
+    rootfs_dir = rootfs_dir.absolute()
+    extract_dir = extract_dir.absolute()
+    if kmod_path is not None:
+        kmod_path = kmod_path.absolute()
+    shared_dir = Path(os.path.commonpath([str(repo_root), str(base_dir)]))
+
+    if not rootfs_dir.is_dir():
+        raise RuntimeError(f"Rootfs is missing: {rootfs_dir}")
+    paths = [rootfs_dir, extract_dir]
+    if kmod_path is not None:
+        paths.append(kmod_path)
+    for path in paths:
+        try:
+            path.relative_to(shared_dir)
+        except ValueError as e:
+            raise RuntimeError(
+                "Path must be inside shared repository root "
+                f"{shared_dir}: {path}"
+            ) from e
+
+    guest_command = _create_guest_command(
+        repo_root,
+        kmod_path,
+        shared_dir,
+        command,
+    )
+    pre_chroot_setup = _create_pre_chroot_setup(
+        release,
+        extract_dir,
+        kmod_path,
+        shared_dir,
+    )
+    initrd = _create_initrd(
+        release,
+        extract_dir,
+        rootfs_dir,
+        shared_dir,
+        pre_chroot_setup,
+        guest_command,
+        shared_fs,
+    )
+    vmlinuz = _find_vmlinuz(release, extract_dir)
+
+    if log_path is not None:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with contextlib.ExitStack() as stack:
+        block_img = stack.enter_context(_create_block_image())
+        tempdir = stack.enter_context(tempfile.TemporaryDirectory())
+        stdin = None
+        if log_path is not None:
+            stdin = subprocess.DEVNULL
+        sock: Optional[Path] = None
+        if shared_fs == SHARED_FS_VIRTIOFS:
+            sock = Path(tempdir) / "virtiofs.sock"
+            stack.enter_context(_start_virtiofsd(sock, shared_dir))
+        args = [qemu]
+        if os.access("/dev/kvm", os.R_OK | os.W_OK):
+            args += ["--enable-kvm", "-cpu", "host"]
+
+        if log_path:
+            serial_args = ["-serial", "stdio", "-monitor", "none"]
+        else:
+            serial_args = ["-serial", "stdio", "-monitor", "none"]
+
+        kernel_cmdline = "console=ttyS0 panic=-1"
+        if not log.verbose:
+            kernel_cmdline = "quiet loglevel=1 " + kernel_cmdline
+
+        args += [
+            # fmt: off
+            "-display", "none",
+            "-nodefaults",
+            "-no-reboot",
+
+            "-kernel", str(vmlinuz),
+            "-initrd", str(initrd),
+            "-append", kernel_cmdline,
+
+            "-smp", "2",
+            *_qemu_memory_args(shared_fs),
+
+            *serial_args,
+            "-device", "virtio-rng",
+            "-device", "vmcoreinfo",
+            *_qemu_host_share_args(shared_fs, shared_dir, sock),
+            "-drive", f"file={block_img},if=virtio,format=raw",
+            # fmt: on
+        ]
+
+        result = _run_qemu(
+            args,
+            log_path,
+            log.verbose,
+            stdin,
+        )
+        if result != 0:
+            if log_path:
+                raise RuntimeError(
+                    f"qemu exited with {result}, see log: {log_path}"
+                )
+            else:
+                raise RuntimeError(f"qemu exited with {result}")
+
+    if log_path:
+        output = log_path.read_bytes()
+        if b"DRGN_VMTEST: PASS" not in output:
+            raise RuntimeError(
+                f"VM test run did not succeed, see log: {log_path}"
+            )

--- a/testing/vm/chroot.py
+++ b/testing/vm/chroot.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+"""Chroot execution helpers for testing.vm."""
+import shlex
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+
+@dataclass(frozen=True)
+class BindMount:
+    source: Path
+    destination: str
+    readonly: bool = False
+
+
+def _rootfs_mount_target(rootfs: Path, destination: str) -> Path:
+    if not destination.startswith("/"):
+        raise ValueError(
+            f"Destination must be an absolute path: {destination}"
+        )
+    return rootfs / destination.lstrip("/")
+
+
+def run_in_chroot(rootfs: Path, command: str, binds: List[BindMount]) -> None:
+    lines = ["set -euo pipefail"]
+    mount_targets = []
+
+    for bind in binds:
+        target = _rootfs_mount_target(rootfs, bind.destination)
+        mount_targets.append(target)
+        source = bind.source.absolute()
+        lines.append(f"mkdir -p {shlex.quote(str(target))}")
+        lines.append(
+            "mount --bind "
+            f"{shlex.quote(str(source))} {shlex.quote(str(target))}"
+        )
+        if bind.readonly:
+            lines.append(
+                "mount -o remount,ro,bind " f"{shlex.quote(str(target))}"
+            )
+
+    mount_targets.append(Path("/proc"))
+    lines.append(f"mount -t proc proc {_rootfs_mount_target(rootfs, '/proc')}")
+
+    lines.append("cleanup() {")
+    lines.append("  status=$?")
+    for target in reversed(mount_targets):
+        lines.append(f"  umount -l {shlex.quote(str(target))} || true")
+    lines.append("  exit $status")
+    lines.append("}")
+    lines.append("trap cleanup EXIT")
+    lines.append(
+        "chroot "
+        f"{shlex.quote(str(rootfs))} /bin/bash -lc {shlex.quote(command)}"
+    )
+
+    script = "\n".join(lines)
+    subprocess.run(
+        [
+            "unshare",
+            "--mount",
+            "--user",
+            "--map-root-user",
+            "--fork",
+            "--pid",
+            "/bin/bash",
+            "-lc",
+            script,
+        ],
+        check=True,
+    )

--- a/testing/vm/chroot.py
+++ b/testing/vm/chroot.py
@@ -4,16 +4,15 @@
 import argparse
 import shlex
 import subprocess
-from dataclasses import dataclass
 from pathlib import Path
 from typing import List
+from typing import NamedTuple
 
 
-@dataclass(frozen=True)
-class BindMount:
+class BindMount(NamedTuple):
     source: Path
     destination: str
-    readonly: bool = False
+    readonly: bool
 
 
 def _rootfs_mount_target(rootfs: Path, destination: str) -> Path:
@@ -24,7 +23,12 @@ def _rootfs_mount_target(rootfs: Path, destination: str) -> Path:
     return rootfs / destination.lstrip("/")
 
 
-def run_in_chroot(rootfs: Path, command: str, binds: List[BindMount]) -> None:
+def run_in_chroot(
+    rootfs: Path,
+    command: str,
+    binds: List[BindMount],
+    verbose: bool = False,
+) -> None:
     lines = ["set -euo pipefail"]
     mount_targets = []
 
@@ -76,6 +80,10 @@ def run_in_chroot(rootfs: Path, command: str, binds: List[BindMount]) -> None:
     )
 
     script = "\n".join(lines)
+    if verbose:
+        stdout = stderr = None
+    else:
+        stdout = stderr = subprocess.DEVNULL
     subprocess.run(
         [
             "unshare",
@@ -89,6 +97,8 @@ def run_in_chroot(rootfs: Path, command: str, binds: List[BindMount]) -> None:
             script,
         ],
         check=True,
+        stdout=stdout,
+        stderr=stderr,
     )
 
 
@@ -163,6 +173,7 @@ def main() -> None:
         args.rootfs.absolute(),
         _command_to_shell(args.command),
         binds=binds,
+        verbose=True,
     )
 
 

--- a/testing/vm/chroot.py
+++ b/testing/vm/chroot.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 """Chroot execution helpers for testing.vm."""
+import argparse
 import shlex
 import subprocess
 from dataclasses import dataclass
@@ -41,8 +42,10 @@ def run_in_chroot(rootfs: Path, command: str, binds: List[BindMount]) -> None:
                 "mount -o remount,ro,bind " f"{shlex.quote(str(target))}"
             )
 
-    mount_targets.append(Path("/proc"))
-    lines.append(f"mount -t proc proc {_rootfs_mount_target(rootfs, '/proc')}")
+    proc_target = _rootfs_mount_target(rootfs, "/proc")
+    lines.append(f"mkdir -p {shlex.quote(str(proc_target))}")
+    mount_targets.append(proc_target)
+    lines.append(f"mount -t proc proc {shlex.quote(str(proc_target))}")
 
     lines.append("cleanup() {")
     lines.append("  status=$?")
@@ -71,3 +74,81 @@ def run_in_chroot(rootfs: Path, command: str, binds: List[BindMount]) -> None:
         ],
         check=True,
     )
+
+
+def _parse_bind(spec: str, readonly: bool) -> BindMount:
+    if ":" not in spec:
+        raise ValueError(
+            f"Invalid bind mount {spec!r}; expected SRC:DST format"
+        )
+    source_str, destination = spec.split(":", 1)
+    if not source_str:
+        raise ValueError(f"Bind mount source path is empty: {spec!r}")
+    if not destination:
+        raise ValueError(f"Bind mount destination path is empty: {spec!r}")
+    return BindMount(Path(source_str), destination, readonly=readonly)
+
+
+def _command_to_shell(command: List[str]) -> str:
+    if not command:
+        return "/bin/bash"
+    if command[0] == "--":
+        command = command[1:]
+    if not command:
+        return "/bin/bash"
+    return " ".join(shlex.quote(arg) for arg in command)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run command in OL chroot")
+    parser.add_argument(
+        "rootfs",
+        type=Path,
+        help="Rootfs directory to chroot into",
+    )
+    parser.add_argument(
+        "--bind",
+        action="append",
+        default=[],
+        metavar="SRC:DST",
+        help="Bind mount host SRC to chroot DST (read-write)",
+    )
+    parser.add_argument(
+        "--ro-bind",
+        action="append",
+        default=[],
+        metavar="SRC:DST",
+        help="Bind mount host SRC to chroot DST (read-only)",
+    )
+    parser.add_argument(
+        "command",
+        nargs=argparse.REMAINDER,
+        help="Command to execute in chroot",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+
+    if not args.rootfs.is_dir():
+        raise SystemExit(f"Rootfs does not exist: {args.rootfs}")
+
+    binds = []
+    try:
+        for spec in args.bind:
+            binds.append(_parse_bind(spec, readonly=False))
+        for spec in args.ro_bind:
+            binds.append(_parse_bind(spec, readonly=True))
+    except ValueError as e:
+        raise SystemExit(str(e)) from e
+
+    run_in_chroot(
+        args.rootfs.absolute(),
+        _command_to_shell(args.command),
+        binds=binds,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/testing/vm/chroot.py
+++ b/testing/vm/chroot.py
@@ -42,6 +42,22 @@ def run_in_chroot(rootfs: Path, command: str, binds: List[BindMount]) -> None:
                 "mount -o remount,ro,bind " f"{shlex.quote(str(target))}"
             )
 
+    for host_path, dst in (
+        (Path("/etc/resolv.conf"), "/etc/resolv.conf"),
+        (Path("/etc/hosts"), "/etc/hosts"),
+    ):
+        if not host_path.is_file():
+            raise RuntimeError(f"Required host file is missing: {host_path}")
+        target = _rootfs_mount_target(rootfs, dst)
+        mount_targets.append(target)
+        lines.append(f"mkdir -p {shlex.quote(str(target.parent))}")
+        lines.append(f"touch {shlex.quote(str(target))}")
+        lines.append(
+            "mount --bind "
+            f"{shlex.quote(str(host_path))} {shlex.quote(str(target))}"
+        )
+        lines.append("mount -o remount,ro,bind " f"{shlex.quote(str(target))}")
+
     proc_target = _rootfs_mount_target(rootfs, "/proc")
     lines.append(f"mkdir -p {shlex.quote(str(proc_target))}")
     mount_targets.append(proc_target)

--- a/testing/vm/config.py
+++ b/testing/vm/config.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+"""Configuration objects and target matrix for testing.vm."""
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+from typing import Union
+
+from testing.litevm.rpm import TestKernel
+from testing.util import BASE_DIR
+
+
+@dataclass(frozen=True)
+class VmTarget:
+    name: str
+    ol_ver: int
+    uek_ver: Union[int, str]
+    arch: str
+    kernel: TestKernel
+
+
+@dataclass(frozen=True)
+class VmPaths:
+    extract_dir: Path
+    yum_cache_dir: Path
+    rootfs_dir: Path
+    work_dir: Path
+
+    @property
+    def kmod_dir(self) -> Path:
+        return self.work_dir / "kmod"
+
+    @property
+    def logs_dir(self) -> Path:
+        return self.work_dir / "logs"
+
+    @property
+    def junit_dir(self) -> Path:
+        return self.work_dir / "junit"
+
+
+def default_paths() -> VmPaths:
+    work_dir = BASE_DIR / "vm"
+    return VmPaths(
+        extract_dir=BASE_DIR / "rpmextract",
+        yum_cache_dir=BASE_DIR / "yumcache",
+        rootfs_dir=work_dir / "rootfs",
+        work_dir=work_dir,
+    )
+
+
+def _kernel_for_uek(
+    ol_ver: int,
+    uek_ver: Union[int, str],
+    arch: str,
+) -> TestKernel:
+    if uek_ver == "next":
+        return TestKernel(
+            ol_ver,
+            uek_ver,
+            arch,
+            [
+                "kernel-ueknext-core",
+                "kernel-ueknext-modules",
+                "kernel-ueknext-modules-core",
+                "kernel-ueknext-devel",
+            ],
+            yum_fmt=(
+                "https://yum.oracle.com/repo/OracleLinux/OL{ol_ver}/"
+                "developer/UEK{uek_ver}/{arch}/"
+            ),
+            pkgbase="kernel-ueknext",
+        )
+    elif uek_ver == 8:
+        return TestKernel(
+            ol_ver,
+            uek_ver,
+            arch,
+            [
+                "kernel-uek-core",
+                "kernel-uek-modules",
+                "kernel-uek-modules-core",
+                "kernel-uek-devel",
+            ],
+        )
+    elif uek_ver == 7:
+        return TestKernel(
+            ol_ver,
+            uek_ver,
+            arch,
+            [
+                "kernel-uek-core",
+                "kernel-uek-modules",
+                "kernel-uek-devel",
+            ],
+        )
+    elif uek_ver == 6:
+        return TestKernel(
+            ol_ver,
+            uek_ver,
+            arch,
+            [
+                "kernel-uek",
+                "kernel-uek-devel",
+            ],
+        )
+    raise ValueError(f"Unsupported UEK target: UEK{uek_ver}")
+
+
+def _target(ol_ver: int, uek_ver: Union[int, str], arch: str) -> VmTarget:
+    uek_suffix = "ueknext" if uek_ver == "next" else f"uek{uek_ver}"
+    name = f"ol{ol_ver}-{uek_suffix}-{arch}"
+    return VmTarget(
+        name=name,
+        ol_ver=ol_ver,
+        uek_ver=uek_ver,
+        arch=arch,
+        kernel=_kernel_for_uek(ol_ver, uek_ver, arch),
+    )
+
+
+TARGETS: List[VmTarget] = [
+    _target(10, "next", "x86_64"),
+    _target(10, 8, "x86_64"),
+    _target(9, "next", "x86_64"),
+    _target(9, 8, "x86_64"),
+    _target(9, 7, "x86_64"),
+    _target(8, 7, "x86_64"),
+    _target(8, 6, "x86_64"),
+]

--- a/testing/vm/config.py
+++ b/testing/vm/config.py
@@ -1,10 +1,10 @@
 # Copyright (c) 2026, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 """Configuration objects and target matrix for testing.vm."""
+import enum
 from pathlib import Path
 from typing import List
 from typing import NamedTuple
-from typing import Union
 
 
 SHARED_FS_AUTO = "auto"
@@ -14,45 +14,68 @@ SHARED_FS_CHOICES = (SHARED_FS_AUTO, SHARED_FS_9P, SHARED_FS_VIRTIOFS)
 SUPPORTED_SHARED_FS = (SHARED_FS_9P, SHARED_FS_VIRTIOFS)
 
 
+class KernelKind(enum.Enum):
+    UEK4 = "uek4"
+    UEK5 = "uek5"
+    UEK6 = "uek6"
+    UEK7 = "uek7"
+    UEK8 = "uek8"
+    UEKNEXT = "ueknext"
+    RHCK = "rhck"
+
+
 class KernelCategory(NamedTuple):
     ol_ver: int
-    uek_ver: Union[int, str]
+    kind: KernelKind
     arch: str
 
     @property
-    def uek_name(self) -> str:
-        return "ueknext" if self.uek_ver == "next" else f"uek{self.uek_ver}"
+    def uek_ver(self) -> int:
+        if self.kind in (KernelKind.UEKNEXT, KernelKind.RHCK):
+            raise ValueError(f"{self.kind.name} has no UEK version")
+        return int(self.kind.name[3:])
 
     @property
     def name(self) -> str:
-        return f"ol{self.ol_ver}-{self.uek_name}-{self.arch}"
+        return f"ol{self.ol_ver}-{self.kind.value}-{self.arch}"
 
     @property
     def slug(self) -> str:
-        return f"ol{self.ol_ver}uek{self.uek_ver}{self.arch}"
+        return f"ol{self.ol_ver}{self.kind.value}{self.arch}"
 
     @property
     def rpmbase(self) -> str:
-        if self.uek_ver == "next":
+        if self.kind == KernelKind.UEKNEXT:
             return "kernel-ueknext"
+        elif self.kind == KernelKind.RHCK:
+            return "kernel"
         else:
             return "kernel-uek"
 
     def rpms(self) -> List[str]:
-        if self.uek_ver in ("next", 8):
+        if self.kind == KernelKind.RHCK:
+            if self.ol_ver == 8:
+                subpkgs = ["-core", "-modules", "-devel"]
+            else:
+                subpkgs = ["-core", "-modules-core", "-devel"]
+        elif self.kind in (KernelKind.UEKNEXT, KernelKind.UEK8):
             subpkgs = ["-core", "-modules", "-modules-core", "-devel"]
-        elif self.uek_ver == 7:
+        elif self.kind == KernelKind.UEK7:
             subpkgs = ["-core", "-modules", "-devel"]
-        elif self.uek_ver in (4, 5, 6):
+        elif self.kind in (KernelKind.UEK4, KernelKind.UEK5, KernelKind.UEK6):
             subpkgs = ["", "-devel"]
         else:
-            raise ValueError(f"Unsupported UEK target '{self.uek_ver}'")
+            raise ValueError(
+                f"Unsupported target kernel kind '{self.kind.value}'"
+            )
         return [f"{self.rpmbase}{subpkg}" for subpkg in subpkgs]
 
     @property
     def shared_fs(self) -> str:
-        if self.uek_ver == 6:
+        if self.kind == KernelKind.UEK6:
             return SHARED_FS_9P
+        elif self.kind in (KernelKind.UEK4, KernelKind.UEK5):
+            raise ValueError("VM testing is not supported for UEK4, UEK5")
         return SHARED_FS_VIRTIOFS
 
 
@@ -103,11 +126,14 @@ class VmLayout(NamedTuple):
 
 
 TARGETS = [
-    KernelCategory(10, "next", "x86_64"),
-    KernelCategory(10, 8, "x86_64"),
-    KernelCategory(9, "next", "x86_64"),
-    KernelCategory(9, 8, "x86_64"),
-    KernelCategory(9, 7, "x86_64"),
-    KernelCategory(8, 7, "x86_64"),
-    KernelCategory(8, 6, "x86_64"),
+    KernelCategory(10, KernelKind.UEKNEXT, "x86_64"),
+    KernelCategory(10, KernelKind.UEK8, "x86_64"),
+    KernelCategory(10, KernelKind.RHCK, "x86_64"),
+    KernelCategory(9, KernelKind.UEKNEXT, "x86_64"),
+    KernelCategory(9, KernelKind.UEK8, "x86_64"),
+    KernelCategory(9, KernelKind.UEK7, "x86_64"),
+    KernelCategory(9, KernelKind.RHCK, "x86_64"),
+    KernelCategory(8, KernelKind.UEK7, "x86_64"),
+    KernelCategory(8, KernelKind.UEK6, "x86_64"),
+    KernelCategory(8, KernelKind.RHCK, "x86_64"),
 ]

--- a/testing/vm/config.py
+++ b/testing/vm/config.py
@@ -1,30 +1,85 @@
 # Copyright (c) 2026, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 """Configuration objects and target matrix for testing.vm."""
-from dataclasses import dataclass
 from pathlib import Path
 from typing import List
+from typing import NamedTuple
 from typing import Union
 
-from testing.litevm.rpm import TestKernel
-from testing.util import BASE_DIR
+
+SHARED_FS_AUTO = "auto"
+SHARED_FS_9P = "9p"
+SHARED_FS_VIRTIOFS = "virtiofs"
+SHARED_FS_CHOICES = (SHARED_FS_AUTO, SHARED_FS_9P, SHARED_FS_VIRTIOFS)
+SUPPORTED_SHARED_FS = (SHARED_FS_9P, SHARED_FS_VIRTIOFS)
 
 
-@dataclass(frozen=True)
-class VmTarget:
-    name: str
+class KernelCategory(NamedTuple):
     ol_ver: int
     uek_ver: Union[int, str]
     arch: str
-    kernel: TestKernel
+
+    @property
+    def uek_name(self) -> str:
+        return "ueknext" if self.uek_ver == "next" else f"uek{self.uek_ver}"
+
+    @property
+    def name(self) -> str:
+        return f"ol{self.ol_ver}-{self.uek_name}-{self.arch}"
+
+    @property
+    def slug(self) -> str:
+        return f"ol{self.ol_ver}uek{self.uek_ver}{self.arch}"
+
+    @property
+    def rpmbase(self) -> str:
+        if self.uek_ver == "next":
+            return "kernel-ueknext"
+        else:
+            return "kernel-uek"
+
+    def rpms(self) -> List[str]:
+        if self.uek_ver in ("next", 8):
+            subpkgs = ["-core", "-modules", "-modules-core", "-devel"]
+        elif self.uek_ver == 7:
+            subpkgs = ["-core", "-modules", "-devel"]
+        elif self.uek_ver in (4, 5, 6):
+            subpkgs = ["", "-devel"]
+        else:
+            raise ValueError(f"Unsupported UEK target '{self.uek_ver}'")
+        return [f"{self.rpmbase}{subpkg}" for subpkg in subpkgs]
+
+    @property
+    def shared_fs(self) -> str:
+        if self.uek_ver == 6:
+            return SHARED_FS_9P
+        return SHARED_FS_VIRTIOFS
 
 
-@dataclass(frozen=True)
-class VmPaths:
-    extract_dir: Path
-    yum_cache_dir: Path
-    rootfs_dir: Path
-    work_dir: Path
+class KernelVer(NamedTuple):
+    category: KernelCategory
+    release: str
+    urls: List[str]
+
+
+class VmLayout(NamedTuple):
+    base_dir: Path
+
+    @property
+    def extract_dir(self) -> Path:
+        return self.base_dir / "rpmextract"
+
+    @property
+    def yum_cache_dir(self) -> Path:
+        return self.base_dir / "yumcache"
+
+    @property
+    def work_dir(self) -> Path:
+        return self.base_dir / "vm"
+
+    @property
+    def rootfs_dir(self) -> Path:
+        return self.work_dir / "rootfs"
 
     @property
     def kmod_dir(self) -> Path:
@@ -34,97 +89,25 @@ class VmPaths:
     def logs_dir(self) -> Path:
         return self.work_dir / "logs"
 
-    @property
-    def junit_dir(self) -> Path:
-        return self.work_dir / "junit"
+    def rootfs_path(self, ol_ver: int) -> Path:
+        return self.rootfs_dir / f"ol{ol_ver}"
+
+    def extract_path(self, release: str) -> Path:
+        return self.extract_dir / release
+
+    def kmod_path(self, release: str) -> Path:
+        return self.kmod_dir / release / "drgntools_test.ko"
+
+    def log_path(self, target_name: str, mode_name: str) -> Path:
+        return self.logs_dir / target_name / f"{mode_name}.log"
 
 
-def default_paths() -> VmPaths:
-    work_dir = BASE_DIR / "vm"
-    return VmPaths(
-        extract_dir=BASE_DIR / "rpmextract",
-        yum_cache_dir=BASE_DIR / "yumcache",
-        rootfs_dir=work_dir / "rootfs",
-        work_dir=work_dir,
-    )
-
-
-def _kernel_for_uek(
-    ol_ver: int,
-    uek_ver: Union[int, str],
-    arch: str,
-) -> TestKernel:
-    if uek_ver == "next":
-        return TestKernel(
-            ol_ver,
-            uek_ver,
-            arch,
-            [
-                "kernel-ueknext-core",
-                "kernel-ueknext-modules",
-                "kernel-ueknext-modules-core",
-                "kernel-ueknext-devel",
-            ],
-            yum_fmt=(
-                "https://yum.oracle.com/repo/OracleLinux/OL{ol_ver}/"
-                "developer/UEK{uek_ver}/{arch}/"
-            ),
-            pkgbase="kernel-ueknext",
-        )
-    elif uek_ver == 8:
-        return TestKernel(
-            ol_ver,
-            uek_ver,
-            arch,
-            [
-                "kernel-uek-core",
-                "kernel-uek-modules",
-                "kernel-uek-modules-core",
-                "kernel-uek-devel",
-            ],
-        )
-    elif uek_ver == 7:
-        return TestKernel(
-            ol_ver,
-            uek_ver,
-            arch,
-            [
-                "kernel-uek-core",
-                "kernel-uek-modules",
-                "kernel-uek-devel",
-            ],
-        )
-    elif uek_ver == 6:
-        return TestKernel(
-            ol_ver,
-            uek_ver,
-            arch,
-            [
-                "kernel-uek",
-                "kernel-uek-devel",
-            ],
-        )
-    raise ValueError(f"Unsupported UEK target: UEK{uek_ver}")
-
-
-def _target(ol_ver: int, uek_ver: Union[int, str], arch: str) -> VmTarget:
-    uek_suffix = "ueknext" if uek_ver == "next" else f"uek{uek_ver}"
-    name = f"ol{ol_ver}-{uek_suffix}-{arch}"
-    return VmTarget(
-        name=name,
-        ol_ver=ol_ver,
-        uek_ver=uek_ver,
-        arch=arch,
-        kernel=_kernel_for_uek(ol_ver, uek_ver, arch),
-    )
-
-
-TARGETS: List[VmTarget] = [
-    _target(10, "next", "x86_64"),
-    _target(10, 8, "x86_64"),
-    _target(9, "next", "x86_64"),
-    _target(9, 8, "x86_64"),
-    _target(9, 7, "x86_64"),
-    _target(8, 7, "x86_64"),
-    _target(8, 6, "x86_64"),
+TARGETS = [
+    KernelCategory(10, "next", "x86_64"),
+    KernelCategory(10, 8, "x86_64"),
+    KernelCategory(9, "next", "x86_64"),
+    KernelCategory(9, 8, "x86_64"),
+    KernelCategory(9, 7, "x86_64"),
+    KernelCategory(8, 7, "x86_64"),
+    KernelCategory(8, 6, "x86_64"),
 ]

--- a/testing/vm/kmod.py
+++ b/testing/vm/kmod.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from testing.vm.chroot import BindMount
 from testing.vm.chroot import run_in_chroot
+from testing.vm.config import KernelKind
 from testing.vm.config import KernelVer
 from testing.vm.config import VmLayout
 from testing.vm.logging import VmLogger
@@ -54,11 +55,11 @@ def ensure_kmod(
 
     command_parts = ["set -euo pipefail"]
 
-    if kernel.category.ol_ver == 8 and kernel.category.uek_ver == 7:
+    if kernel.category.ol_ver == 8 and kernel.category.kind == KernelKind.UEK7:
         command_parts.append("source /opt/rh/gcc-toolset-11/enable")
-    elif kernel.category.ol_ver == 9 and kernel.category.uek_ver in (
-        8,
-        "next",
+    elif kernel.category.ol_ver == 9 and kernel.category.kind in (
+        KernelKind.UEK8,
+        KernelKind.UEKNEXT,
     ):
         command_parts.append("source /opt/rh/gcc-toolset-14/enable")
 

--- a/testing/vm/kmod.py
+++ b/testing/vm/kmod.py
@@ -30,7 +30,7 @@ def ensure_kmod(
         out_path.is_file()
         and out_path.stat().st_mtime >= source_file.stat().st_mtime
     ):
-        log.already_present("kernel module", out_path)
+        log.already_done("build kmod", out_path)
         return out_path
 
     if skip_build:
@@ -38,6 +38,7 @@ def ensure_kmod(
             f"Kernel module does not exist: {out_path} "
             "(disable --skip-kmod-build)"
         )
+    log.working("build kmod", out_path)
 
     out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -93,6 +94,6 @@ def ensure_kmod(
         )
 
     shutil.copy2(source_module, out_path)
-    log.built("kernel module", out_path)
+    log.done("build kmod", out_path)
 
     return out_path

--- a/testing/vm/kmod.py
+++ b/testing/vm/kmod.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+"""Kernel module build orchestration for testing.vm."""
+import shutil
+from pathlib import Path
+
+from testing.vm.chroot import BindMount
+from testing.vm.chroot import run_in_chroot
+from testing.vm.config import VmTarget
+
+
+def ensure_kmod(
+    rootfs: Path,
+    target: VmTarget,
+    release: str,
+    repo_root: Path,
+    extract_root: Path,
+    out_root: Path,
+    skip_build: bool = False,
+) -> Path:
+    out_dir = out_root / release
+    out_path = out_dir / "drgntools_test.ko"
+    if out_path.is_file():
+        return out_path
+
+    if skip_build:
+        raise RuntimeError(
+            f"Kernel module does not exist: {out_path} "
+            "(disable --skip-kmod-build)"
+        )
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    repo_root = repo_root.absolute()
+    extract_root = extract_root.absolute()
+    source_dir = repo_root / "testing/kmod"
+    kernel_dir = extract_root / release / "usr/src/kernels" / release
+
+    if not kernel_dir.is_dir():
+        raise RuntimeError(f"Kernel build tree not found: {kernel_dir}")
+
+    source_module = source_dir / "drgntools_test.ko"
+    if source_module.exists():
+        source_module.unlink()
+
+    command_parts = ["set -euo pipefail"]
+
+    if target.ol_ver == 8 and target.uek_ver == 7:
+        command_parts.append("source /opt/rh/gcc-toolset-11/enable")
+    elif target.ol_ver == 9 and target.uek_ver in (8, "next"):
+        command_parts.append("source /opt/rh/gcc-toolset-14/enable")
+
+    make = (
+        f"make -C /mnt/extract/{release}/usr/src/kernels/{release} "
+        "M=/mnt/repo/testing/kmod"
+    )
+    command_parts.extend(
+        [
+            f"{make} clean",
+            f"{make} modules",
+        ]
+    )
+
+    run_in_chroot(
+        rootfs,
+        " ; ".join(command_parts),
+        binds=[
+            BindMount(source=repo_root, destination="/mnt/repo"),
+            BindMount(source=extract_root, destination="/mnt/extract"),
+        ],
+    )
+
+    if not source_module.is_file():
+        raise RuntimeError(
+            "Kernel module build completed but output was not produced: "
+            f"{source_module}"
+        )
+
+    shutil.copy2(source_module, out_path)
+
+    return out_path

--- a/testing/vm/kmod.py
+++ b/testing/vm/kmod.py
@@ -6,21 +6,31 @@ from pathlib import Path
 
 from testing.vm.chroot import BindMount
 from testing.vm.chroot import run_in_chroot
-from testing.vm.config import VmTarget
+from testing.vm.config import KernelVer
+from testing.vm.config import VmLayout
+from testing.vm.logging import VmLogger
 
 
 def ensure_kmod(
     rootfs: Path,
-    target: VmTarget,
-    release: str,
+    kernel: KernelVer,
     repo_root: Path,
-    extract_root: Path,
-    out_root: Path,
+    layout: VmLayout,
+    log: VmLogger,
     skip_build: bool = False,
 ) -> Path:
-    out_dir = out_root / release
-    out_path = out_dir / "drgntools_test.ko"
-    if out_path.is_file():
+    repo_root = repo_root.absolute()
+    source_dir = repo_root / "testing/kmod"
+    source_file = source_dir / "drgntools_test.c"
+
+    release = kernel.release
+    out_path = layout.kmod_path(release)
+    out_dir = out_path.parent
+    if (
+        out_path.is_file()
+        and out_path.stat().st_mtime >= source_file.stat().st_mtime
+    ):
+        log.already_present("kernel module", out_path)
         return out_path
 
     if skip_build:
@@ -31,9 +41,7 @@ def ensure_kmod(
 
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    repo_root = repo_root.absolute()
-    extract_root = extract_root.absolute()
-    source_dir = repo_root / "testing/kmod"
+    extract_root = layout.extract_dir.absolute()
     kernel_dir = extract_root / release / "usr/src/kernels" / release
 
     if not kernel_dir.is_dir():
@@ -45,9 +53,12 @@ def ensure_kmod(
 
     command_parts = ["set -euo pipefail"]
 
-    if target.ol_ver == 8 and target.uek_ver == 7:
+    if kernel.category.ol_ver == 8 and kernel.category.uek_ver == 7:
         command_parts.append("source /opt/rh/gcc-toolset-11/enable")
-    elif target.ol_ver == 9 and target.uek_ver in (8, "next"):
+    elif kernel.category.ol_ver == 9 and kernel.category.uek_ver in (
+        8,
+        "next",
+    ):
         command_parts.append("source /opt/rh/gcc-toolset-14/enable")
 
     make = (
@@ -65,9 +76,14 @@ def ensure_kmod(
         rootfs,
         " ; ".join(command_parts),
         binds=[
-            BindMount(source=repo_root, destination="/mnt/repo"),
-            BindMount(source=extract_root, destination="/mnt/extract"),
+            BindMount(
+                source=repo_root, destination="/mnt/repo", readonly=False
+            ),
+            BindMount(
+                source=extract_root, destination="/mnt/extract", readonly=False
+            ),
         ],
+        verbose=log.verbose,
     )
 
     if not source_module.is_file():
@@ -77,5 +93,6 @@ def ensure_kmod(
         )
 
     shutil.copy2(source_module, out_path)
+    log.built("kernel module", out_path)
 
     return out_path

--- a/testing/vm/logging.py
+++ b/testing/vm/logging.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+"""Logging helpers for testing.vm."""
+import os
+from pathlib import Path
+
+
+def default_verbose() -> bool:
+    return any(
+        os.environ.get(name) for name in ("CI", "GITHUB_ACTIONS", "GITLAB_CI")
+    )
+
+
+class VmLogger:
+    def __init__(self, verbose: bool, interactive: bool) -> None:
+        self.verbose = verbose
+        self.interactive = interactive
+
+    def begin_target(self, target: str) -> None:
+        if self.verbose:
+            print(f"Beginning build & test for {target}...")
+
+    def begin_test(self, target: str, mode: str, fs_mode: str) -> None:
+        print(f"Running {mode} tests for {target} using {fs_mode}...")
+
+    def fail_test(self, target: str, mode: str) -> None:
+        print(f"FAILED: {target} {mode}")
+
+    def pass_test(self, target: str, mode: str) -> None:
+        print(f"PASS: {target} {mode}")
+
+    def already_done(self, kind: str, path: Path) -> None:
+        if self.verbose:
+            print(f"Already done: {kind}: {path}", flush=True)
+
+    def working(self, kind: str, path: Path) -> None:
+        # This should be printed even when non-verbose, otherwise users
+        # tend to get testy about why it's taking so long.
+        print(f"Working : {kind}: {path}...", flush=True)
+
+    def done(self, kind: str, path: Path) -> None:
+        print(f"Complete: {kind}: {path}", flush=True)
+
+    def message(self, text: str, verbose_only: bool = False) -> None:
+        if self.verbose or not verbose_only:
+            print(text, flush=True)

--- a/testing/vm/logging.py
+++ b/testing/vm/logging.py
@@ -23,6 +23,9 @@ class VmLogger:
     def begin_test(self, target: str, mode: str, fs_mode: str) -> None:
         print(f"Running {mode} tests for {target} using {fs_mode}...")
 
+    def skip_test(self, target: str, mode: str, reason: str) -> None:
+        print(f"Skipping {mode} tests for {target}: {reason}")
+
     def fail_test(self, target: str, mode: str) -> None:
         print(f"FAILED: {target} {mode}")
 

--- a/testing/vm/rootfs.py
+++ b/testing/vm/rootfs.py
@@ -58,13 +58,17 @@ def _build_rootfs(
     if ol_ver == 8:
         rpm_list.extend(
             [
+                # For UEK7 module build
                 "gcc-toolset-11-gcc",
                 "gcc-toolset-11-binutils-devel",
+                # For RHCK module build (ORC generation)
+                "elfutils-libelf-devel",
             ]
         )
     elif ol_ver == 9:
         rpm_list.extend(
             [
+                # For UEK8 module build
                 "gcc-toolset-14-gcc",
                 "gcc-toolset-14-binutils-devel",
             ]

--- a/testing/vm/rootfs.py
+++ b/testing/vm/rootfs.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+"""Rootfs build and validation for testing.vm."""
+import inspect
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def _validate_rootfs(path: Path) -> None:
+    expected = [
+        "bin/bash",
+        "usr/bin/python3",
+        "usr/bin/make",
+        "usr/bin/gcc",
+    ]
+    for relpath in expected:
+        fullpath = path / relpath
+        if not (fullpath.is_file() or fullpath.is_symlink()):
+            raise RuntimeError(f"Rootfs is missing required file: {fullpath}")
+
+
+def _build_rootfs(ol_ver: int, build_dir: Path) -> None:
+    if not shutil.which("podman"):
+        raise RuntimeError("podman is required to build rootfs")
+
+    build_dir.mkdir(parents=True, exist_ok=True)
+
+    # The necessary RPMs for running drgn-tools tests within a VM, and
+    # also building a kernel module.
+    rpm_list = [
+        "drgn",
+        "python3",
+        "python3-pip",
+        "bash",
+        "coreutils",
+        "findutils",
+        "gcc",
+        "make",
+        "binutils-devel",
+        "dwarves",
+    ]
+    if ol_ver == 8:
+        rpm_list.extend(
+            [
+                "platform-python",
+                "gcc-toolset-11-gcc",
+                "gcc-toolset-11-binutils-devel",
+            ]
+        )
+    elif ol_ver == 9:
+        rpm_list.extend(
+            [
+                "gcc-toolset-14-gcc",
+                "gcc-toolset-14-binutils-devel",
+            ]
+        )
+    rpms = " ".join(rpm_list)
+    install_cmd = inspect.cleandoc(
+        f"""
+        set -euo pipefail
+        dnf -y --releasever={ol_ver} --installroot=/rootfs \\
+               --setopt=install_weak_deps=False \\
+               --setopt=tsflags=nodocs \\
+               --enablerepo=ol{ol_ver}_addons \\
+               --enablerepo=ol{ol_ver}_codeready_builder \\
+               --refresh \\
+               install {rpms}
+        dnf -y --installroot=/rootfs clean all;
+        rm -rf /rootfs/var/cache/dnf
+    """
+    )
+
+    subprocess.run(
+        [
+            "podman",
+            "run",
+            "--rm",
+            "--mount",
+            f"type=bind,src={build_dir},dst=/rootfs",
+            f"oraclelinux:{ol_ver}",
+            "bash",
+            "-lc",
+            install_cmd,
+        ],
+        check=True,
+    )
+
+
+def _rmtree_rootfs(path: Path) -> None:
+    if not path.is_dir():
+        path.unlink()
+        return
+
+    for root, dirs, files in path.walk():
+        # The rootfs contains many directories which have 555 permissions.
+        # This blocks modifying the contents of any of the directories,
+        # including deleting them. The resulting error makes the user want to
+        # use sudo, which works reasonably safely, but is not necessary. Just
+        # set the proper directory permissions.
+        root.chmod(0o755)
+    shutil.rmtree(root)
+
+
+def ensure_rootfs(
+    ol_ver: int,
+    rootfs_dir: Path,
+    skip_build: bool = False,
+) -> Path:
+    rootfs_dir.mkdir(parents=True, exist_ok=True)
+
+    final_dir = rootfs_dir / f"ol{ol_ver}"
+    if final_dir.is_dir():
+        _validate_rootfs(final_dir)
+        return final_dir
+
+    if skip_build:
+        raise RuntimeError(
+            f"Rootfs {final_dir} does not exist (disable --skip-rootfs-build)"
+        )
+
+    building_dir = rootfs_dir / f"ol{ol_ver}.building"
+    if building_dir.exists():
+        _rmtree_rootfs(building_dir)
+
+    try:
+        _build_rootfs(ol_ver, building_dir)
+        _validate_rootfs(building_dir)
+        os.rename(building_dir, final_dir)
+    except BaseException:
+        _rmtree_rootfs(building_dir)
+        raise
+
+    _validate_rootfs(final_dir)
+    return final_dir

--- a/testing/vm/rootfs.py
+++ b/testing/vm/rootfs.py
@@ -51,6 +51,7 @@ def _build_rootfs(
         "make",
         "binutils-devel",
         "dwarves",
+        "hostname",
         "util-linux",  # needed for "setsid" command
         # "e2fsprogs", - not required, busybox provides it in initrd
     ]
@@ -145,13 +146,14 @@ def ensure_rootfs(
     final_dir = layout.rootfs_path(category.ol_ver)
     if final_dir.is_dir():
         _validate_rootfs(final_dir)
-        log.already_present("rootfs", final_dir)
+        log.already_done("build rootfs", final_dir)
         return final_dir
 
     if skip_build:
         raise RuntimeError(
             f"Rootfs {final_dir} does not exist (disable --skip-rootfs-build)"
         )
+    log.working("build rootfs", final_dir)
 
     building_dir = layout.rootfs_dir / f"ol{category.ol_ver}.building"
     if building_dir.exists():
@@ -170,5 +172,5 @@ def ensure_rootfs(
         _rmtree_rootfs(building_dir)
         raise
 
-    log.built("rootfs", final_dir)
+    log.done("build rootfs", final_dir)
     return final_dir

--- a/testing/vm/rootfs.py
+++ b/testing/vm/rootfs.py
@@ -94,7 +94,7 @@ def _build_rootfs(
         "run",
         "--rm",
         "--mount",
-        f"type=bind,src={build_dir},dst=/rootfs",
+        f"type=bind,src={build_dir},dst=/rootfs,relabel=private",
         f"oraclelinux:{ol_ver}",
         "bash",
         "-lc",

--- a/testing/vm/rootfs.py
+++ b/testing/vm/rootfs.py
@@ -1,11 +1,17 @@
 # Copyright (c) 2026, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 """Rootfs build and validation for testing.vm."""
+import contextlib
 import inspect
 import os
 import shutil
 import subprocess
 from pathlib import Path
+
+from testing.vm.chroot import run_in_chroot
+from testing.vm.config import KernelCategory
+from testing.vm.config import VmLayout
+from testing.vm.logging import VmLogger
 
 
 def _validate_rootfs(path: Path) -> None:
@@ -21,7 +27,12 @@ def _validate_rootfs(path: Path) -> None:
             raise RuntimeError(f"Rootfs is missing required file: {fullpath}")
 
 
-def _build_rootfs(ol_ver: int, build_dir: Path) -> None:
+def _build_rootfs(
+    ol_ver: int,
+    build_dir: Path,
+    output_log: Path,
+    log: VmLogger,
+) -> None:
     if not shutil.which("podman"):
         raise RuntimeError("podman is required to build rootfs")
 
@@ -40,11 +51,12 @@ def _build_rootfs(ol_ver: int, build_dir: Path) -> None:
         "make",
         "binutils-devel",
         "dwarves",
+        "util-linux",  # needed for "setsid" command
+        # "e2fsprogs", - not required, busybox provides it in initrd
     ]
     if ol_ver == 8:
         rpm_list.extend(
             [
-                "platform-python",
                 "gcc-toolset-11-gcc",
                 "gcc-toolset-11-binutils-devel",
             ]
@@ -72,20 +84,39 @@ def _build_rootfs(ol_ver: int, build_dir: Path) -> None:
     """
     )
 
-    subprocess.run(
-        [
-            "podman",
-            "run",
-            "--rm",
-            "--mount",
-            f"type=bind,src={build_dir},dst=/rootfs",
-            f"oraclelinux:{ol_ver}",
-            "bash",
-            "-lc",
-            install_cmd,
-        ],
-        check=True,
-    )
+    command = [
+        "podman",
+        "run",
+        "--rm",
+        "--mount",
+        f"type=bind,src={build_dir},dst=/rootfs",
+        f"oraclelinux:{ol_ver}",
+        "bash",
+        "-lc",
+        install_cmd,
+    ]
+    with contextlib.ExitStack() as stack:
+        stdout = None
+        stderr = None
+
+        # Redirect stdout to file unless verbose
+        if not log.verbose:
+            output_log.parent.mkdir(parents=True, exist_ok=True)
+            stdout = stack.enter_context(output_log.open("wb"))
+            stderr = subprocess.STDOUT
+
+        subprocess.run(command, stdout=stdout, stderr=stderr, check=True)
+
+        # Install pytest by running in the newly created chroot:
+        # This can be done in the above step, but OL8's python is symlinked via
+        # an absolute path through /etc/alternatives, which conflicts with the
+        # build container's rootfs. This makes things messier than we'd like.
+        run_in_chroot(
+            build_dir,
+            "python3 -m pip install 'pytest<7'",
+            [],
+            verbose=log.verbose,
+        )
 
 
 def _rmtree_rootfs(path: Path) -> None:
@@ -93,26 +124,28 @@ def _rmtree_rootfs(path: Path) -> None:
         path.unlink()
         return
 
-    for root, dirs, files in path.walk():
+    for root, dirs, files in os.walk(str(path)):
         # The rootfs contains many directories which have 555 permissions.
         # This blocks modifying the contents of any of the directories,
         # including deleting them. The resulting error makes the user want to
         # use sudo, which works reasonably safely, but is not necessary. Just
         # set the proper directory permissions.
-        root.chmod(0o755)
-    shutil.rmtree(root)
+        Path(root).chmod(0o755)
+    shutil.rmtree(str(path))
 
 
 def ensure_rootfs(
-    ol_ver: int,
-    rootfs_dir: Path,
+    category: KernelCategory,
+    layout: VmLayout,
+    log: VmLogger,
     skip_build: bool = False,
 ) -> Path:
-    rootfs_dir.mkdir(parents=True, exist_ok=True)
+    layout.rootfs_dir.mkdir(parents=True, exist_ok=True)
 
-    final_dir = rootfs_dir / f"ol{ol_ver}"
+    final_dir = layout.rootfs_path(category.ol_ver)
     if final_dir.is_dir():
         _validate_rootfs(final_dir)
+        log.already_present("rootfs", final_dir)
         return final_dir
 
     if skip_build:
@@ -120,17 +153,22 @@ def ensure_rootfs(
             f"Rootfs {final_dir} does not exist (disable --skip-rootfs-build)"
         )
 
-    building_dir = rootfs_dir / f"ol{ol_ver}.building"
+    building_dir = layout.rootfs_dir / f"ol{category.ol_ver}.building"
     if building_dir.exists():
         _rmtree_rootfs(building_dir)
 
     try:
-        _build_rootfs(ol_ver, building_dir)
+        _build_rootfs(
+            category.ol_ver,
+            building_dir,
+            layout.logs_dir / "rootfs" / f"ol{category.ol_ver}.log",
+            log,
+        )
         _validate_rootfs(building_dir)
         os.rename(building_dir, final_dir)
     except BaseException:
         _rmtree_rootfs(building_dir)
         raise
 
-    _validate_rootfs(final_dir)
+    log.built("rootfs", final_dir)
     return final_dir

--- a/testing/vm/runner.py
+++ b/testing/vm/runner.py
@@ -13,6 +13,7 @@ from testing.vm.artifacts import ensure_kernel
 from testing.vm.artifacts import resolve_kernel
 from testing.vm.boot import run_in_vm
 from testing.vm.config import KernelCategory
+from testing.vm.config import KernelKind
 from testing.vm.config import SHARED_FS_AUTO
 from testing.vm.config import SHARED_FS_CHOICES
 from testing.vm.config import TARGETS
@@ -221,6 +222,11 @@ def main() -> None:
                     f"{target.name}_{mode_name}",
                     f"Run {mode_name.upper()} tests for {target.name}",
                 ):
+                    if kernel.category.kind == KernelKind.RHCK and ctf:
+                        log.skip_test(
+                            target.name, mode_name, "CTF unsupported"
+                        )
+                        continue
                     log.begin_test(target.name, mode_name, shared_fs)
                     log_path = layout.log_path(target.name, mode_name)
                     run_command = _command_for_mode(

--- a/testing/vm/runner.py
+++ b/testing/vm/runner.py
@@ -121,14 +121,14 @@ def _parse_args() -> argparse.Namespace:
         "--interactive",
         "-i",
         action="store_true",
-        help="Connect stdout/stdin of the test to the terminal",
+        help="Connect stdout/stdin of the VM to the terminal",
     )
     parser.add_argument(
         "--verbose",
         "-v",
         action="store_true",
         default=default_verbose(),
-        help="Enable verbose orchestration and VM output",
+        help="Print output from builds & increase kernel log level",
     )
     parser.add_argument(
         "--shared-fs",
@@ -160,19 +160,24 @@ def _parse_args() -> argparse.Namespace:
 def main() -> None:
     args = _parse_args()
     layout = VmLayout(args.base_dir)
-    log = VmLogger(args.verbose)
+    log = VmLogger(args.verbose, args.interactive)
 
     base_command = args.command if args.command else _default_command()
+    is_pytest = _is_pytest_command(base_command)
     targets = _select_targets(args.kernel)
     if not targets:
         raise SystemExit(f"No targets matched --kernel {args.kernel!r}")
 
     repo_root = Path.cwd().absolute()
     modes = []
-    if args.dwarf:
-        modes.append(("dwarf", False))
-    if args.ctf:
-        modes.append(("ctf", True))
+    if not is_pytest:
+        args.interactive = True
+        modes.append(("interactive", False))
+    else:
+        if args.dwarf:
+            modes.append(("dwarf", False))
+        if args.ctf:
+            modes.append(("ctf", True))
 
     failures: List[str] = []
 
@@ -183,6 +188,7 @@ def main() -> None:
                 f"{target.name}_setup",
                 f"Set up rootfs, kernel RPMs, and kmod for {target.name}",
             ):
+                log.begin_target(target.name)
                 rootfs = ensure_rootfs(
                     target,
                     layout,
@@ -215,31 +221,29 @@ def main() -> None:
                     f"{target.name}_{mode_name}",
                     f"Run {mode_name.upper()} tests for {target.name}",
                 ):
-                    log.message(
-                        (
-                            f"Running {mode_name} tests for {target.name} "
-                            f"using {shared_fs}"
-                        ),
-                        verbose_only=False,
-                    )
+                    log.begin_test(target.name, mode_name, shared_fs)
                     log_path = layout.log_path(target.name, mode_name)
                     run_command = _command_for_mode(
                         base_command,
                         ctf,
                     )
-                    run_in_vm(
-                        kernel,
-                        rootfs,
-                        layout,
-                        repo_root,
-                        run_command,
-                        None if args.interactive else log_path,
-                        log,
-                        kmod_path=kmod_path,
-                        shared_fs=shared_fs,
-                    )
-                    if not args.interactive and args.verbose:
-                        log.message(f"VM log: {log_path}", verbose_only=True)
+                    try:
+                        run_in_vm(
+                            kernel,
+                            rootfs,
+                            layout,
+                            repo_root,
+                            run_command,
+                            None if args.interactive else log_path,
+                            log,
+                            kmod_path=kmod_path,
+                            shared_fs=shared_fs,
+                        )
+                    except RuntimeError as e:
+                        failures.append(f"{target.name} {mode_name}: {e}")
+                        log.fail_test(target.name, mode_name)
+                    else:
+                        log.pass_test(target.name, mode_name)
         except BaseException as e:
             failures.append(f"{target.name}: {e}")
             if isinstance(e, (SystemExit, KeyboardInterrupt)):

--- a/testing/vm/runner.py
+++ b/testing/vm/runner.py
@@ -1,74 +1,82 @@
 # Copyright (c) 2026, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
-"""New VM test runner orchestration (initial implementation)."""
+"""New VM test runner orchestration."""
 import argparse
 import fnmatch
-import shlex
 import sys
 from pathlib import Path
 from typing import List
 
+from testing.util import BASE_DIR
 from testing.util import ci_section
-from testing.vm.artifacts import ensure_kernel_artifacts
-from testing.vm.config import default_paths
+from testing.vm.artifacts import ensure_kernel
+from testing.vm.artifacts import resolve_kernel
+from testing.vm.boot import run_in_vm
+from testing.vm.config import KernelCategory
+from testing.vm.config import SHARED_FS_AUTO
+from testing.vm.config import SHARED_FS_CHOICES
 from testing.vm.config import TARGETS
-from testing.vm.config import VmPaths
-from testing.vm.config import VmTarget
+from testing.vm.config import VmLayout
 from testing.vm.kmod import ensure_kmod
+from testing.vm.logging import default_verbose
+from testing.vm.logging import VmLogger
 from testing.vm.rootfs import ensure_rootfs
 
 
-def _select_targets(pattern: str = "*") -> List[VmTarget]:
+def _select_targets(pattern: str = "*") -> List[KernelCategory]:
     return [t for t in TARGETS if fnmatch.fnmatch(t.name, pattern)]
 
 
 def _default_command() -> List[str]:
-    return [sys.executable, "-m", "pytest", "tests"]
+    return ["python3", "-m", "pytest", "tests"]
 
 
-def _stub_test_execution(
-    target: VmTarget, command: List[str], kmod_path: Path
-) -> None:
-    command_str = " ".join(shlex.quote(arg) for arg in command)
-    print(
-        "TODO: VM boot/test execution not implemented yet "
-        f"for {target.name}; would run: {command_str}; "
-        f"module: {kmod_path}"
-    )
+def _is_pytest_command(command: List[str]) -> bool:
+    if not command:
+        return False
+    if "pytest" in command:
+        return True
+    for i, arg in enumerate(command[:-1]):
+        if arg == "-m" and command[i + 1] == "pytest":
+            return True
+    return False
+
+
+def _command_for_mode(
+    base_command: List[str],
+    ctf: bool,
+) -> List[str]:
+    command = list(base_command)
+    is_pytest = _is_pytest_command(command)
+
+    if not is_pytest:
+        return command
+
+    if ctf and "--ctf" not in command:
+        command.append("--ctf")
+
+    return command
+
+
+def _shared_fs_for_target(target: KernelCategory, shared_fs: str) -> str:
+    if shared_fs == SHARED_FS_AUTO:
+        return target.shared_fs
+    return shared_fs
 
 
 def _parse_args() -> argparse.Namespace:
-    defaults = default_paths()
-
     parser = argparse.ArgumentParser(description="testing.vm runner")
     parser.add_argument(
         "--kernel",
+        "-k",
         default="*",
         help="Match against target slug (example: ol9-uek8-*)",
     )
     parser.add_argument(
-        "--extract-dir",
+        "--base-dir",
         type=Path,
-        default=defaults.extract_dir,
-        help="Directory for extracted kernel RPMs",
-    )
-    parser.add_argument(
-        "--yum-cache-dir",
-        type=Path,
-        default=defaults.yum_cache_dir,
-        help="Directory for YUM metadata and RPM cache",
-    )
-    parser.add_argument(
-        "--rootfs-dir",
-        type=Path,
-        default=defaults.rootfs_dir,
-        help="Directory containing OL rootfs chroots",
-    )
-    parser.add_argument(
-        "--work-dir",
-        type=Path,
-        default=defaults.work_dir,
-        help="Directory for VM work artifacts",
+        default=BASE_DIR,
+        help="Base directory for cached and generated test artifacts",
     )
     parser.add_argument(
         "--skip-rootfs-build",
@@ -78,7 +86,10 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--skip-rpm-fetch",
         action="store_true",
-        help="Do not fetch/extract kernel RPMs (requires existing extract dir)",
+        help=(
+            "Do not download repodata or RPMs "
+            "(requires cached metadata/RPMs)"
+        ),
     )
     parser.add_argument(
         "--skip-kmod-build",
@@ -86,75 +97,160 @@ def _parse_args() -> argparse.Namespace:
         help="Do not build kernel module (requires existing .ko output)",
     )
     parser.add_argument(
+        "--skip-all",
+        "-n",
+        action="store_true",
+        help=(
+            "Activate all --skip-* options "
+            "(requires everything already built)"
+        ),
+    )
+    parser.add_argument(
+        "--no-ctf",
+        dest="ctf",
+        action="store_false",
+        help="Skip CTF mode",
+    )
+    parser.add_argument(
+        "--no-dwarf",
+        dest="dwarf",
+        action="store_false",
+        help="Skip DWARF mode",
+    )
+    parser.add_argument(
+        "--interactive",
+        "-i",
+        action="store_true",
+        help="Connect stdout/stdin of the test to the terminal",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        default=default_verbose(),
+        help="Enable verbose orchestration and VM output",
+    )
+    parser.add_argument(
+        "--shared-fs",
+        choices=SHARED_FS_CHOICES,
+        default=SHARED_FS_AUTO,
+        help=(
+            "Host/guest shared filesystem. auto uses 9p for UEK6 and "
+            "virtiofs for newer UEKs"
+        ),
+    )
+    parser.add_argument(
         "command",
         nargs="*",
-        help="Command to run in-guest once VM execution is implemented",
+        help="Command to run in guest (default: python3 -m pytest tests)",
     )
-    return parser.parse_args()
 
-
-def _paths_from_args(args: argparse.Namespace) -> VmPaths:
-    return VmPaths(
-        extract_dir=args.extract_dir,
-        yum_cache_dir=args.yum_cache_dir,
-        rootfs_dir=args.rootfs_dir,
-        work_dir=args.work_dir,
-    )
+    args = parser.parse_args()
+    if not args.dwarf and not args.ctf:
+        raise SystemExit(
+            "Both --no-dwarf and --no-ctf were set, nothing to run"
+        )
+    if args.skip_all:
+        args.skip_rootfs_build = True
+        args.skip_rpm_fetch = True
+        args.skip_kmod_build = True
+    return args
 
 
 def main() -> None:
     args = _parse_args()
-    paths = _paths_from_args(args)
+    layout = VmLayout(args.base_dir)
+    log = VmLogger(args.verbose)
 
-    command = args.command if args.command else _default_command()
+    base_command = args.command if args.command else _default_command()
     targets = _select_targets(args.kernel)
     if not targets:
         raise SystemExit(f"No targets matched --kernel {args.kernel!r}")
 
     repo_root = Path.cwd().absolute()
+    modes = []
+    if args.dwarf:
+        modes.append(("dwarf", False))
+    if args.ctf:
+        modes.append(("ctf", True))
+
+    failures: List[str] = []
 
     for target in targets:
-        with ci_section(
-            f"{target.name}_rootfs",
-            f"Build rootfs for {target.name}",
-        ):
-            rootfs = ensure_rootfs(
-                target.ol_ver,
-                paths.rootfs_dir,
-                skip_build=args.skip_rootfs_build,
-            )
+        try:
+            shared_fs = _shared_fs_for_target(target, args.shared_fs)
+            with ci_section(
+                f"{target.name}_setup",
+                f"Set up rootfs, kernel RPMs, and kmod for {target.name}",
+            ):
+                rootfs = ensure_rootfs(
+                    target,
+                    layout,
+                    log,
+                    skip_build=args.skip_rootfs_build,
+                )
+                kernel = resolve_kernel(
+                    target,
+                    layout,
+                    log,
+                    skip_fetch=args.skip_rpm_fetch,
+                )
+                ensure_kernel(
+                    kernel,
+                    layout,
+                    log,
+                    skip_fetch=args.skip_rpm_fetch,
+                )
+                kmod_path = ensure_kmod(
+                    rootfs,
+                    kernel,
+                    repo_root,
+                    layout,
+                    log,
+                    skip_build=args.skip_kmod_build,
+                )
 
-        with ci_section(
-            f"{target.name}_kernel",
-            f"Download/extract kernel RPMs for {target.name}",
-        ):
-            artifacts = ensure_kernel_artifacts(
-                target.kernel,
-                paths.extract_dir,
-                paths.yum_cache_dir,
-                skip_fetch=args.skip_rpm_fetch,
-            )
+            for mode_name, ctf in modes:
+                with ci_section(
+                    f"{target.name}_{mode_name}",
+                    f"Run {mode_name.upper()} tests for {target.name}",
+                ):
+                    log.message(
+                        (
+                            f"Running {mode_name} tests for {target.name} "
+                            f"using {shared_fs}"
+                        ),
+                        verbose_only=False,
+                    )
+                    log_path = layout.log_path(target.name, mode_name)
+                    run_command = _command_for_mode(
+                        base_command,
+                        ctf,
+                    )
+                    run_in_vm(
+                        kernel,
+                        rootfs,
+                        layout,
+                        repo_root,
+                        run_command,
+                        None if args.interactive else log_path,
+                        log,
+                        kmod_path=kmod_path,
+                        shared_fs=shared_fs,
+                    )
+                    if not args.interactive and args.verbose:
+                        log.message(f"VM log: {log_path}", verbose_only=True)
+        except BaseException as e:
+            failures.append(f"{target.name}: {e}")
+            if isinstance(e, (SystemExit, KeyboardInterrupt)):
+                print("\ninterrupted")
+                break
 
-        with ci_section(
-            f"{target.name}_kmod",
-            f"Build test kernel module for {target.name}",
-        ):
-            kmod_path = ensure_kmod(
-                rootfs,
-                target,
-                artifacts.release,
-                repo_root,
-                paths.extract_dir,
-                paths.kmod_dir,
-                skip_build=args.skip_kmod_build,
-            )
-            print(f"Built module: {kmod_path}")
-
-        with ci_section(
-            f"{target.name}_run",
-            f"Run tests for {target.name}",
-        ):
-            _stub_test_execution(target, command, kmod_path)
+    if failures:
+        print("VM test failures:")
+        for failure in failures:
+            print(f"- {failure}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/testing/vm/runner.py
+++ b/testing/vm/runner.py
@@ -3,6 +3,7 @@
 """New VM test runner orchestration."""
 import argparse
 import fnmatch
+import shutil
 import sys
 from pathlib import Path
 from typing import List
@@ -141,6 +142,11 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--delete-after-test",
+        action="store_true",
+        help="Delete downloaded & extracted RPMs after tests for target",
+    )
+    parser.add_argument(
         "command",
         nargs="*",
         help="Command to run in guest (default: python3 -m pytest tests)",
@@ -250,6 +256,11 @@ def main() -> None:
                         log.fail_test(target.name, mode_name)
                     else:
                         log.pass_test(target.name, mode_name)
+
+            if args.delete_after_test:
+                log.message("Deleting RPM cache and extraction directory")
+                shutil.rmtree(layout.extract_path(kernel.release))
+                shutil.rmtree(layout.yum_cache_dir / kernel.category.slug)
         except BaseException as e:
             failures.append(f"{target.name}: {e}")
             if isinstance(e, (SystemExit, KeyboardInterrupt)):

--- a/testing/vm/runner.py
+++ b/testing/vm/runner.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+"""New VM test runner orchestration (initial implementation)."""
+import argparse
+import fnmatch
+import shlex
+import sys
+from pathlib import Path
+from typing import List
+
+from testing.util import ci_section
+from testing.vm.artifacts import ensure_kernel_artifacts
+from testing.vm.config import default_paths
+from testing.vm.config import TARGETS
+from testing.vm.config import VmPaths
+from testing.vm.config import VmTarget
+from testing.vm.kmod import ensure_kmod
+from testing.vm.rootfs import ensure_rootfs
+
+
+def _select_targets(pattern: str = "*") -> List[VmTarget]:
+    return [t for t in TARGETS if fnmatch.fnmatch(t.name, pattern)]
+
+
+def _default_command() -> List[str]:
+    return [sys.executable, "-m", "pytest", "tests"]
+
+
+def _stub_test_execution(
+    target: VmTarget, command: List[str], kmod_path: Path
+) -> None:
+    command_str = " ".join(shlex.quote(arg) for arg in command)
+    print(
+        "TODO: VM boot/test execution not implemented yet "
+        f"for {target.name}; would run: {command_str}; "
+        f"module: {kmod_path}"
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    defaults = default_paths()
+
+    parser = argparse.ArgumentParser(description="testing.vm runner")
+    parser.add_argument(
+        "--kernel",
+        default="*",
+        help="Match against target slug (example: ol9-uek8-*)",
+    )
+    parser.add_argument(
+        "--extract-dir",
+        type=Path,
+        default=defaults.extract_dir,
+        help="Directory for extracted kernel RPMs",
+    )
+    parser.add_argument(
+        "--yum-cache-dir",
+        type=Path,
+        default=defaults.yum_cache_dir,
+        help="Directory for YUM metadata and RPM cache",
+    )
+    parser.add_argument(
+        "--rootfs-dir",
+        type=Path,
+        default=defaults.rootfs_dir,
+        help="Directory containing OL rootfs chroots",
+    )
+    parser.add_argument(
+        "--work-dir",
+        type=Path,
+        default=defaults.work_dir,
+        help="Directory for VM work artifacts",
+    )
+    parser.add_argument(
+        "--skip-rootfs-build",
+        action="store_true",
+        help="Do not build rootfs (requires it to already exist)",
+    )
+    parser.add_argument(
+        "--skip-rpm-fetch",
+        action="store_true",
+        help="Do not fetch/extract kernel RPMs (requires existing extract dir)",
+    )
+    parser.add_argument(
+        "--skip-kmod-build",
+        action="store_true",
+        help="Do not build kernel module (requires existing .ko output)",
+    )
+    parser.add_argument(
+        "command",
+        nargs="*",
+        help="Command to run in-guest once VM execution is implemented",
+    )
+    return parser.parse_args()
+
+
+def _paths_from_args(args: argparse.Namespace) -> VmPaths:
+    return VmPaths(
+        extract_dir=args.extract_dir,
+        yum_cache_dir=args.yum_cache_dir,
+        rootfs_dir=args.rootfs_dir,
+        work_dir=args.work_dir,
+    )
+
+
+def main() -> None:
+    args = _parse_args()
+    paths = _paths_from_args(args)
+
+    command = args.command if args.command else _default_command()
+    targets = _select_targets(args.kernel)
+    if not targets:
+        raise SystemExit(f"No targets matched --kernel {args.kernel!r}")
+
+    repo_root = Path.cwd().absolute()
+
+    for target in targets:
+        with ci_section(
+            f"{target.name}_rootfs",
+            f"Build rootfs for {target.name}",
+        ):
+            rootfs = ensure_rootfs(
+                target.ol_ver,
+                paths.rootfs_dir,
+                skip_build=args.skip_rootfs_build,
+            )
+
+        with ci_section(
+            f"{target.name}_kernel",
+            f"Download/extract kernel RPMs for {target.name}",
+        ):
+            artifacts = ensure_kernel_artifacts(
+                target.kernel,
+                paths.extract_dir,
+                paths.yum_cache_dir,
+                skip_fetch=args.skip_rpm_fetch,
+            )
+
+        with ci_section(
+            f"{target.name}_kmod",
+            f"Build test kernel module for {target.name}",
+        ):
+            kmod_path = ensure_kmod(
+                rootfs,
+                target,
+                artifacts.release,
+                repo_root,
+                paths.extract_dir,
+                paths.kmod_dir,
+                skip_build=args.skip_kmod_build,
+            )
+            print(f"Built module: {kmod_path}")
+
+        with ci_section(
+            f"{target.name}_run",
+            f"Run tests for {target.name}",
+        ):
+            _stub_test_execution(target, command, kmod_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,7 +220,8 @@ def pytest_configure(config):
             getattr(drgn, "__version__", "unknown"),
         )
     )
-    extra_debuginfo = _extra_live_debuginfo()
+    kmod = os.environ.get("DRGNTOOLS_TEST_KMOD")
+    extra_debuginfo = [kmod] if kmod else []
     if CTF:
         try:
             from drgn.helpers.linux.ctf import load_ctf
@@ -230,6 +231,12 @@ def pytest_configure(config):
             # is loaded if we don't have a path).
             load_ctf(PROG, path=CTF_FILE)
             PROG.cache["using_ctf"] = True
+            if kmod:
+                import _drgn
+
+                _drgn._linux_helper_load_module_ctf(
+                    PROG, "drgntools_test", kmod
+                )
             # Mark in-tree modules as having debuginfo, so that the module API
             # doesn't attempt to load debuginfo implicitly.
             for module in PROG.modules():
@@ -237,8 +244,6 @@ def pytest_configure(config):
                     module.debug_file_status = ModuleFileStatus.DONT_NEED
         except ModuleNotFoundError:
             raise Exception("CTF is not supported, cannot run CTF test")
-        if extra_debuginfo:
-            PROG.load_debug_info(extra_debuginfo)
     elif DEBUGINFO:
         PROG.load_debug_info(DEBUGINFO + extra_debuginfo)
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,29 @@ KVER: Optional[KernelVersion] = None
 PROG: Optional[drgn.Program] = None
 
 
+def _extra_live_debuginfo() -> List[Path]:
+    """
+    Return additional debuginfo files for live-kernel tests.
+
+    The VM runner sets DRGNTOOLS_TEST_KMOD to the out-of-tree module path. We
+    explicitly load that module's debuginfo before default module discovery so
+    drgn doesn't fail the session with MissingDebugInfoError.
+    """
+    kmod = os.environ.get("DRGNTOOLS_TEST_KMOD")
+    if not kmod:
+        return []
+    path = Path(kmod)
+    if not path.is_file():
+        pytest.exit(
+            reason=(
+                "error: DRGNTOOLS_TEST_KMOD is set but path does not exist: "
+                f"{path}"
+            ),
+            returncode=1,
+        )
+    return [path]
+
+
 @pytest.fixture(scope="session")
 def prog() -> drgn.Program:
     assert PROG is not None
@@ -197,6 +220,7 @@ def pytest_configure(config):
             getattr(drgn, "__version__", "unknown"),
         )
     )
+    extra_debuginfo = _extra_live_debuginfo()
     if CTF:
         try:
             from drgn.helpers.linux.ctf import load_ctf
@@ -213,9 +237,13 @@ def pytest_configure(config):
                     module.debug_file_status = ModuleFileStatus.DONT_NEED
         except ModuleNotFoundError:
             raise Exception("CTF is not supported, cannot run CTF test")
+        if extra_debuginfo:
+            PROG.load_debug_info(extra_debuginfo)
     elif DEBUGINFO:
-        PROG.load_debug_info(DEBUGINFO)
+        PROG.load_debug_info(DEBUGINFO + extra_debuginfo)
     else:
+        if extra_debuginfo:
+            PROG.load_debug_info(extra_debuginfo)
         # Some UEK versions had mismatched vmlinux build IDs due to packaging
         # issues. Most have been fixed, but for the remainder, set the main
         # module's build ID to None manually, forcing drgn to skip verifying

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -8,6 +8,7 @@ from drgn_tools.module import module_exports
 @pytest.fixture
 def common_mod(prog):
     COMMON_MODS = [
+        "drgntools_test",
         "nf_nat",
         "ib_core",
         "9pnet",


### PR DESCRIPTION
Introduce a new test runner, `testing.vm`, which will replace both the `testing.litevm` and `testing.heavyvm` runners, while adding more features and being overall... better.

The new test runner has the following benefits:
- It runs tests in an Oracle Linux rootfs. This means the tests run in a real OL userspace and can use the official `drgn` RPMs in our tests. (Compared to the old "litevm" runner, which ran in the host's rootfs.)
- The rootfs is built with `dnf --installroot` in a container, which is much faster than scripting the ISO installer, and easier to update than the prebuilt cloud VM images.
- Since the rootfs is manually built and part of the host filesystem, we can install just what we need, keeping the size small. And since we can share the rootfs for each test associated test kernel, we have less duplication. My rootfs directory is less than 2 GiB for all three combined.
- Since the rootfs is not contained in an image, it's easy to run maintainence commands (e.g. installing new packages, compiling kernel modules) in a chroot rather than spinning up a full VM.
- As a direct consequence, we can now build and insert a kernel module for our VM tests.
- The runner now supports testing against Red Hat kernels (RHCK) -- including with the test kernel module.
- Tests run on Oracle Linux host with only standard RPMs - just be sure to use the latest KVM utils stream.
- Tests boot and run much faster! My laptop can run both DWARF + CTF test for OL8/UEK6 in around 15 seconds -- and this requires booting twice.

Some other notes:
- This is a large amount of addition without many changes or deletions. The idea is to add this new framework in parallel to the others. I'll remove the others (`testing.litevm`, `testing.heavyvm`) once this is stable on Github CI.
- I have some follow-ups that I will tackle later based on priority:
  - Make it possible to run tests against specific Python versions in each rootfs. (OL8: python 3.6, 3.12, OL9: 3.9, 
3.12, 3.14 soon, OL10: 3.12, 3.14 soon).
  - Enable running vmcore tests in the chroot for each OL version. This ensures that vmcore tests also use the real bits from our RPMs.
  - Make it easy to drop-in new drgn/drgn-tools RPMs to test them (replacing my ad-hoc testing workflow for testing new RPM releases).
  - Expand support to aarch64 and add this to Gitlab.

There is a known failure on UEK-NEXT due to changes in the slab allocator. Imran is currently taking a look at it, but I don't think this should block merging this.