### PR TITLE
Minor bug fixes and improvements before the release.

### DIFF
--- a/drgn_tools/cli.py
+++ b/drgn_tools/cli.py
@@ -79,7 +79,18 @@ def main() -> None:
         " vmlinux and .ko.debug DWARF debuginfo files)",
     )
     parser.add_argument(
-        "--enable-download", "-g", help="enable downloading debuginfo RPMs"
+        "--enable-download",
+        "-g",
+        action="store_true",
+        help="enable downloading debuginfo RPMs",
+    )
+    parser.add_argument(
+        "--disable-extract",
+        "-E",
+        action="store_false",
+        dest="enable_extract",
+        help="disable extracting local RPMs (use to workaround "
+        "re-extraction issues)",
     )
     args = parser.parse_args()
 
@@ -105,7 +116,7 @@ def main() -> None:
         opts.enable_ctf = False
         opts.disable_dwarf = False
     # This tool has always existed to allow automatic extraction
-    opts.enable_extract = True
+    opts.enable_extract = args.enable_extract
     opts.enable_download = args.enable_download
 
     prog = Program()

--- a/drgn_tools/command.py
+++ b/drgn_tools/command.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+"""Convenience wrappers for drgn's command mode."""
+from typing import Any
+from typing import Callable
+
+
+def _dummy_register(
+    *args: Any, **kwargs: Any
+) -> Callable[[Callable], Callable]:
+    def decorator(f: Callable) -> Callable:
+        return f
+
+    return decorator
+
+
+try:
+    from drgn.commands import parse_shell_command
+    from drgn.commands.linux import linux_kernel_custom_command
+
+    HAVE_DRGN_COMMANDS = True
+except (ImportError, ModuleNotFoundError):
+    HAVE_DRGN_COMMANDS = False
+    linux_kernel_custom_command = _dummy_register
+    parse_shell_command = None
+
+# The _crash module is private, and we should not be surprised or bothered if it
+# changes from under us. Keep it in a separate try/except block so that even if
+# future changes happen to the _crash module, we can still register our linux
+# command.
+try:
+    from drgn.commands._crash import crash_custom_command
+except (ImportError, ModuleNotFoundError):
+    crash_custom_command = _dummy_register

--- a/drgn_tools/corelens.py
+++ b/drgn_tools/corelens.py
@@ -29,6 +29,8 @@ from typing import Sequence
 from typing import Tuple
 
 import drgn
+from drgn import Architecture
+from drgn import Platform
 from drgn import Program
 from drgn import ProgramFlags
 from drgn.cli import version_header as drgn_version_header
@@ -364,7 +366,39 @@ def _load_prog_and_debuginfo(args: argparse.Namespace) -> Program:
     opts.dwarf_dir = args.dwarf_dir
     opts.ctf_file = args.ctf_file
 
-    prog = Program()
+    # Normally drgn can auto-detect this just fine, but flags can specify it
+    # where necessary.
+    vmcoreinfo = None
+    platform = None
+    if args.vmcoreinfo:
+        # Manually specified vmcoreinfo, in case it's not easily accessible in
+        # the dump metadata.
+        with open(args.vmcoreinfo, "rt") as f:
+            vmcoreinfo = f.read()
+        osrel_match = re.search(r"^OSRELEASE=(.*)$", vmcoreinfo, re.M)
+        if not osrel_match:
+            raise ValueError("Invalid vmcoreinfo: missing OSRELEASE")
+        # Specify the architecture using the OSRELEASE in vmcoreinfo. Usually if
+        # vmcoreinfo is not present in the core dump metadata, neither is
+        # architecture. If we can't automatically detect, don't fail, because
+        # the user can still provide it manually via --architecture if all else
+        # fails.
+        osrel = osrel_match.group(1)
+        if osrel.endswith(".x86_64"):
+            platform = Platform(Architecture.X86_64)
+        elif osrel.endswith(".aarch64"):
+            platform = Platform(Architecture.AARCH64)
+    if args.architecture:
+        if args.architecture == "x86_64":
+            platform = Platform(Architecture.X86_64)
+        elif args.architecture == "aarch64":
+            platform = Platform(Architecture.AARCH64)
+        else:
+            raise ValueError(
+                "Invalid architecture: choices are: x86_64, aarch64"
+            )
+
+    prog = Program(vmcoreinfo=vmcoreinfo, platform=platform)
     prog.cache["drgn_tools.debuginfo.options"] = opts
     prog.cache["drgn_tools.debuginfo.vmcore_path"] = args.vmcore
     try:
@@ -571,6 +605,15 @@ def _do_main() -> None:
         "vmcore",
         help="vmcore to run against (use /proc/kcore for live)",
         nargs="?",
+    )
+    parser.add_argument(
+        "--vmcoreinfo",
+        help="manually specify vmcoreinfo as text file",
+    )
+    parser.add_argument(
+        "--architecture",
+        help="manually specify architecture",
+        choices=("x86_64", "aarch64"),
     )
     parser.add_argument(
         "--list",

--- a/drgn_tools/corelens.py
+++ b/drgn_tools/corelens.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2026, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 """
 Run analysis helper code and output to stdout or a directory
@@ -20,10 +20,12 @@ import traceback
 from fnmatch import fnmatch
 from logging.handlers import MemoryHandler
 from pathlib import Path
+from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Sequence
 from typing import Tuple
 
 import drgn
@@ -31,6 +33,9 @@ from drgn import Program
 from drgn import ProgramFlags
 from drgn.cli import version_header as drgn_version_header
 
+from drgn_tools.command import crash_custom_command
+from drgn_tools.command import linux_kernel_custom_command
+from drgn_tools.command import parse_shell_command
 from drgn_tools.debuginfo import drgn_prog_set as register_debug_info_finders
 from drgn_tools.debuginfo import get_debuginfo_config
 from drgn_tools.logging import FilterMissingDebugSymbolsMessages
@@ -790,6 +795,61 @@ def run(prog: Program, cl_cmd: str, outfile: Optional[str] = None) -> None:
     module = all_corelens_modules()[module_name]
     try:
         ns = module._parse_args(args, exit_on_error=False)
+    except _CorelensArgparseEscapeException:
+        return
+    to_run, errors, warnings = _check_module_debuginfo([(module, ns)], prog)
+    _report_errors(errors, warnings)
+    if to_run:
+        module.run(prog, ns)
+
+
+@linux_kernel_custom_command(
+    name="cl",
+    parse=parse_shell_command,
+    description="run a Corelens command",
+    usage="**cl** -L | MODULE [args...]",
+    long_description="foobar",
+)
+@linux_kernel_custom_command(
+    name="corelens",
+    parse=parse_shell_command,
+    description="run a Corelens command",
+    usage="**corelens** -L | MODULE [args...]",
+    long_description="foobar",
+)
+@crash_custom_command(
+    name="cl",
+    parse=parse_shell_command,
+    description="run a Corelens command",
+    usage="**cl** -L | MODULE [args...]",
+    long_description="foobar",
+)
+@crash_custom_command(
+    name="corelens",
+    parse=parse_shell_command,
+    description="run a Corelens command",
+    usage="**corelens** -L | MODULE [args...]",
+    long_description="foobar",
+)
+def drgncrash_command_corelens(
+    prog: Program, name: str, args: Sequence[str], **kwargs: Any
+) -> None:
+    if len(args) < 1:
+        print("error: a module, or -L, is required")
+        return
+
+    if args == ["-L"]:
+        _print_module_listing()
+        return
+
+    module_name, module_args = args[0], args[1:]
+    try:
+        module = all_corelens_modules()[module_name]
+    except KeyError:
+        print(f"error: no such corelens module: '{module_name}'")
+        return
+    try:
+        ns = module._parse_args(list(module_args), exit_on_error=False)
     except _CorelensArgparseEscapeException:
         return
     to_run, errors, warnings = _check_module_debuginfo([(module, ns)], prog)

--- a/drgn_tools/corelens.py
+++ b/drgn_tools/corelens.py
@@ -359,7 +359,7 @@ def _load_prog_and_debuginfo(args: argparse.Namespace) -> Program:
         opts.disable_dwarf = True
     elif args.dwarf:
         opts.enable_ctf = False
-    opts.enable_extract = True
+    opts.enable_extract = args.enable_extract
     opts.enable_download = args.enable_download
     opts.dwarf_dir = args.dwarf_dir
     opts.ctf_file = args.ctf_file
@@ -611,6 +611,13 @@ def _do_main() -> None:
         "--enable-download",
         "-g",
         action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--disable-extract",
+        "-E",
+        action="store_false",
+        dest="enable_extract",
         help=argparse.SUPPRESS,
     )
     grp = parser.add_mutually_exclusive_group()

--- a/drgn_tools/cpuinfo.py
+++ b/drgn_tools/cpuinfo.py
@@ -15,6 +15,7 @@ from drgn import sizeof
 from drgn import TypeKind
 from drgn.helpers.linux.bitops import for_each_set_bit
 from drgn.helpers.linux.bitops import test_bit
+from drgn.helpers.linux.cpumask import for_each_online_cpu
 from drgn.helpers.linux.percpu import per_cpu
 
 from drgn_tools.corelens import CorelensModule
@@ -76,7 +77,7 @@ def x86_get_cpu_info(prog: Program) -> Dict[str, Any]:
 
     :returns: a dictionary of the cpuinfo data
     """
-    cpus = int(prog["nr_cpu_ids"])
+    cpus = sum(1 for _ in for_each_online_cpu(prog))
 
     if "cpu_data" in prog:
         cpuinfo_struct = prog["cpu_data"].read_()

--- a/drgn_tools/debuginfo.py
+++ b/drgn_tools/debuginfo.py
@@ -826,6 +826,9 @@ def drgn_prog_set(prog: Program) -> None:
     if not prog.flags & ProgramFlags.IS_LINUX_KERNEL:
         return
 
+    # Register the corelens commands in the drgn linux kernel / crash CLI
+    import drgn_tools.corelens  # noqa
+
     # It seems possible for plugins to be registered multiple times if there's
     # an issue with the importlib metadata due to the installation. Defensively
     # avoid re-running.

--- a/drgn_tools/module.py
+++ b/drgn_tools/module.py
@@ -35,13 +35,13 @@ __all__ = (
 
 
 def module_is_in_tree(module: Module) -> bool:
-    # Note that this will return True for Ksplice "cold patch" modules. We
-    # cannot reliably detect them, but they do not match the shipped debuginfo,
-    # and drgn rightly rejects their debuginfo.
+    # Note that this will return True for Ksplice "cold patch" modules built
+    # prior to roughly November 2025.
     return (
         module.prog.flags & ProgramFlags.IS_LINUX_KERNEL
         and isinstance(module, RelocatableModule)
         and not (module.object.taints & (1 << Taint.OOT_MODULE))
+        and ".note.ksplice" not in module.section_addresses
     )
 
 
@@ -267,6 +267,7 @@ class ModuleLoadSummary(NamedTuple):
 
     total_mods: int
     ksplice_mods: List[RelocatableModule]
+    ksplice_coldpatch: List[RelocatableModule]
     other_oot: List[RelocatableModule]
     loaded_mods: List[RelocatableModule]
     mismatched_mods: List[RelocatableModule]
@@ -277,6 +278,10 @@ class ModuleLoadSummary(NamedTuple):
         details = []
         if self.ksplice_mods:
             details.append(f"{len(self.ksplice_mods)} are ksplices")
+        if self.ksplice_mods:
+            details.append(
+                f"{len(self.ksplice_coldpatch)} are ksplice cold-patched modules"
+            )
         if self.other_oot:
             details.append(
                 f"{len(self.other_oot)} are other out-of-tree modules"
@@ -315,6 +320,7 @@ class ModuleLoadSummary(NamedTuple):
             "in-tree, mismatched debuginfo (ksplice cold-patch?)",
         )
         add(self.ksplice_mods, "ksplice patches")
+        add(self.ksplice_coldpatch, "ksplice cold-patched modules")
         add(self.other_oot, "other out-of-tree modules")
         return "\n".join(lines)
 
@@ -334,6 +340,7 @@ def get_module_load_summary(prog: Program) -> ModuleLoadSummary:
     """
     total_mods = 0
     ksplice_mods = []
+    ksplice_coldpatch = []
     other_oot = []
     loaded_mods = []
     mismatched_mods = []
@@ -358,6 +365,8 @@ def get_module_load_summary(prog: Program) -> ModuleLoadSummary:
                 mismatched_mods.append(mod)
             else:
                 missing_mods.append(mod)
+        elif ".note.ksplice" in mod.section_addresses:
+            ksplice_coldpatch.append(mod)
         elif mod.name.startswith("ksplice"):
             ksplice_mods.append(mod)
         else:
@@ -365,6 +374,7 @@ def get_module_load_summary(prog: Program) -> ModuleLoadSummary:
     return ModuleLoadSummary(
         total_mods,
         ksplice_mods,
+        ksplice_coldpatch,
         other_oot,
         loaded_mods,
         mismatched_mods,

--- a/drgn_tools/module.py
+++ b/drgn_tools/module.py
@@ -35,12 +35,17 @@ __all__ = (
 
 
 def module_is_in_tree(module: Module) -> bool:
+    # The OOT_MODULE taint may be spoofed by setting the intree modinfo
+    # attribute. It may not even be malicious, just a symptom of a strange build
+    # environment. Built-in kernel modules should not have a proprietary
+    # license, so we can use this as an additional detection flag.
+    likely_oot = (1 << Taint.OOT_MODULE) | (1 << Taint.PROPRIETARY_MODULE)
     # Note that this will return True for Ksplice "cold patch" modules built
     # prior to roughly November 2025.
     return (
         module.prog.flags & ProgramFlags.IS_LINUX_KERNEL
         and isinstance(module, RelocatableModule)
-        and not (module.object.taints & (1 << Taint.OOT_MODULE))
+        and not (module.object.taints & likely_oot)
         and ".note.ksplice" not in module.section_addresses
     )
 

--- a/drgn_tools/nvme.py
+++ b/drgn_tools/nvme.py
@@ -65,10 +65,15 @@ def nvme_ctrl(prog: Program, disk: Object) -> Object:
 
 
 def nvme_disk_driver(prog: Program, disk: Object) -> str:
-    ctrl = nvme_ctrl(prog, disk)
-    if not ctrl:
+    if is_nvme_disk(disk):
+        ctrl = nvme_ctrl(prog, disk)
+        if not ctrl:
+            return "unknown"
+        return ctrl.ops.module.name.string_().decode()
+    elif is_nvme_head(disk):
+        return prog.module(disk.fops).name
+    else:
         return "unknown"
-    return ctrl.ops.module.name.string_().decode()
 
 
 def for_each_nvme_disk(prog: Program) -> Iterable[Object]:

--- a/drgn_tools/nvme.py
+++ b/drgn_tools/nvme.py
@@ -4,6 +4,7 @@ import argparse
 from typing import Any
 from typing import Iterable
 from typing import List
+from typing import Optional
 
 from drgn import cast
 from drgn import container_of
@@ -19,6 +20,38 @@ from drgn_tools.corelens import CorelensModule
 from drgn_tools.module import ensure_debuginfo
 from drgn_tools.table import print_table
 from drgn_tools.util import enum_name_get
+
+
+def _get_nvme_ops(prog: Program) -> Optional[Object]:
+    # First try from cache
+    try:
+        return prog.cache["drgn_tools.nvme_bdev_ops"]
+    except KeyError:
+        pass
+    # Since v5.11 commit ba4fb3205680a ("nvme: rename bdev operations"):
+    try:
+        ops = prog["nvme_bdev_ops"].address_of_()
+    except LookupError:
+        # Prior kernels:
+        try:
+            ops = prog["nvme_fops"].address_of_()
+        except LookupError:
+            return None
+    prog.cache["drgn_tools.nvme_bdev_ops"] = ops
+    return ops
+
+
+def is_nvme_disk(disk: Object) -> bool:
+    ops = _get_nvme_ops(disk.prog_)
+    return ops is not None and disk.fops == ops
+
+
+def is_nvme_head(disk: Object) -> bool:
+    try:
+        ops = disk.prog_["nvme_ns_head_ops"].address_of_()
+    except LookupError:
+        return False
+    return disk.fops == ops
 
 
 def nvme_ctrl(prog: Program, disk: Object) -> Object:
@@ -46,7 +79,7 @@ def for_each_nvme_disk(prog: Program) -> Iterable[Object]:
     :returns: iterable of ``struct nvme_ns *`` in the program
     """
     for disk in for_each_disk(prog):
-        if disk.disk_name.string_().startswith(b"nvme"):
+        if is_nvme_disk(disk):
             yield cast("struct nvme_ns *", disk.private_data)
 
 

--- a/drgn_tools/runq.py
+++ b/drgn_tools/runq.py
@@ -40,8 +40,6 @@ def _print_rt_runq(runqueue: Object) -> None:
             "struct sched_rt_entity", que.address_of_(), "run_list"
         ):
             tsk = container_of(t, "struct task_struct", "rt")
-            if tsk == runqueue.curr:
-                continue
             count += 1
             print(
                 " " * 4,
@@ -65,8 +63,6 @@ def _print_cfs_runq(runqueue: Object) -> None:
     for t in list_for_each_entry(
         "struct task_struct", runq.cfs_tasks.address_of_(), "se.group_node"
     ):
-        if t == runqueue.curr:
-            continue
         count += 1
         print(
             " " * 4,

--- a/testing/vm/boot.py
+++ b/testing/vm/boot.py
@@ -46,6 +46,7 @@ COMMON_INITRD_MODULES = [
     "virtio_pci",
     "virtio_blk",
     "ext4",
+    "nvme",
 ]
 
 VIRTIOFS_INITRD_MODULES = [
@@ -594,6 +595,7 @@ def run_in_vm(
 
     with contextlib.ExitStack() as stack:
         block_img = stack.enter_context(_create_block_image())
+        nvme_img = stack.enter_context(_create_block_image())
         tempdir = stack.enter_context(tempfile.TemporaryDirectory())
         stdin = None
         if log_path is not None:
@@ -632,6 +634,13 @@ def run_in_vm(
             "-device", "vmcoreinfo",
             *_qemu_host_share_args(shared_fs, shared_dir, sock),
             "-drive", f"file={block_img},if=virtio,format=raw",
+
+            # Emulated NVME multipath disk test data
+            "-device", "nvme-subsys,id=subsys0",
+            "-device", "nvme,id=nvme0,serial=foo,subsys=subsys0",
+            "-device", "nvme,id=nvme1,serial=foo,subsys=subsys0",
+            "-drive", f"file={nvme_img},format=raw,if=none,id=nvm-drive",
+            "-device", "nvme-ns,drive=nvm-drive,bus=nvme0,nsid=1,shared=on",
             # fmt: on
         ]
 

--- a/testing/vm/boot.py
+++ b/testing/vm/boot.py
@@ -624,7 +624,7 @@ def run_in_vm(
             "-initrd", str(initrd),
             "-append", kernel_cmdline,
 
-            "-smp", "2",
+            "-smp", "2,maxcpus=4",  # testdata for cpuinfo
             *_qemu_memory_args(shared_fs),
 
             *serial_args,

--- a/testing/vm/rootfs.py
+++ b/testing/vm/rootfs.py
@@ -52,6 +52,10 @@ def _build_rootfs(
         "dwarves",
         "hostname",
         "util-linux",  # needed for "setsid" command
+        # Following commands are not strictly necessary, but make it far easier
+        # to install custom packages into the rootfs ad-hoc.
+        "dnf",
+        f"oraclelinux-release-el{ol_ver}",
         # "e2fsprogs", - not required, busybox provides it in initrd
     ]
     if ol_ver == 8:

--- a/tests/test_cpuinfo.py
+++ b/tests/test_cpuinfo.py
@@ -23,10 +23,13 @@ class TestCpuinfo(DrgnToolsTestCase):
         lines = file.readlines()
         file.close()
         cpu_data_from_proc = dict()
+        nr_cpus = 0
         for line in lines:
             try:
                 title, value = line.split(":")
                 title, value = title.strip(), value.strip()
+                if title == "processor":
+                    nr_cpus += 1
                 cpu_data_from_proc[title] = value
             except Exception:
                 continue
@@ -61,6 +64,10 @@ class TestCpuinfo(DrgnToolsTestCase):
             self.assertEqual(
                 cpu_data_from_corelens["BUG FLAGS"],
                 cpu_data_from_proc["bugs"],
+            )
+            self.assertEqual(
+                cpu_data_from_corelens["CPUS"],
+                nr_cpus,
             )
 
         elif self.prog.platform.arch == Architecture.AARCH64:

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -1,6 +1,7 @@
-# Copyright (c) 2023, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2026 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 from pathlib import Path
+from unittest import mock
 
 from drgn.helpers.linux import for_each_partition
 
@@ -15,8 +16,8 @@ class TestPartition(DrgnToolsTestCase):
 
     @skip_unless_live
     def test_block_helpers(self):
-        partitions_sysfs = set()
-        partitions_drgn = set()
+        partitions_sysfs = []
+        partitions_drgn = []
 
         def sysfs_int(p: Path, s: str, default: int = 0) -> int:
             n = p / s
@@ -29,14 +30,21 @@ class TestPartition(DrgnToolsTestCase):
             size = sysfs_int(block_dev_dir, "size")
             ro = bool(sysfs_int(block_dev_dir, "ro"))
             start = sysfs_int(block_dev_dir, "start")
-            dev = (block_dev_dir / "dev").open().read().strip()
-            maj, min = map(int, dev.split(":"))
+            dev_path = block_dev_dir / "dev"
+            # Hidden gendisks, such as NVMe multipath component namespaces,
+            # have class directories but do not publish a sysfs dev number.
+            if dev_path.exists():
+                dev = dev_path.open().read().strip()
+                maj, minor = map(int, dev.split(":"))
+            else:
+                maj = mock.ANY
+                minor = mock.ANY
             name = block_dev_dir.name
-            partitions_sysfs.add((name, size, ro, start, maj, min))
+            partitions_sysfs.append((name, size, ro, start, maj, minor))
 
         for part in for_each_partition(self.prog):
             info = partition.get_partition_info(part)
-            partitions_drgn.add(
+            partitions_drgn.append(
                 (
                     info.name,
                     info.nr_sects,
@@ -47,4 +55,4 @@ class TestPartition(DrgnToolsTestCase):
                 )
             )
 
-        self.assertEqual(partitions_sysfs, partitions_drgn)
+        self.assertCountEqual(partitions_sysfs, partitions_drgn)

--- a/tests/test_workqueue.py
+++ b/tests/test_workqueue.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 import drgn
-from drgn.helpers.linux.cpumask import for_each_online_cpu
+from drgn.helpers.linux.cpumask import for_each_possible_cpu
 from drgn.helpers.linux.kthread import kthread_data
 from drgn.helpers.linux.percpu import per_cpu
 from drgn.helpers.linux.percpu import per_cpu_ptr
@@ -108,14 +108,14 @@ class TestWorkqueue(DrgnToolsTestCase):
             # evidence that the change should be used.
             cpu_pwqs_list = [
                 per_cpu_ptr(workq.cpu_pwq, cpu)[0].value_()
-                for cpu in for_each_online_cpu(self.prog)
+                for cpu in for_each_possible_cpu(self.prog)
             ]
         else:
             cpu_pwqs_list = [
                 per_cpu_ptr(workq.cpu_pwqs, cpu).value_()
-                for cpu in for_each_online_cpu(self.prog)
+                for cpu in for_each_possible_cpu(self.prog)
             ]
-        self.assertEqual(sorted(pwqs), sorted(cpu_pwqs_list))
+        self.assertCountEqual(pwqs, cpu_pwqs_list)
 
     @skip_live
     def test_for_each_pending_work_on_cpu(self):


### PR DESCRIPTION
This is a bit of a grab-bag of new features and fixes:
- Adds the `%corelens` command for drgn
- Corrects a few bugs that I had failed to address from bugdb
- Add ksplice cold-patch detection for the debuginfo loader.
- Add a fix and workaround for cases where corelens tries to extract debuginfo for modules that aren't in the debuginfo RPM.
- Include the `dnf` package (and yum repositories) in the rootfs.

The live test cases should be passing at this point. I'll need to audit the vmcore test suite to ensure it's still passing. After that, I'll create the PR with packaging changes and the release.