### PR TITLE
ci: test runc for LiteVM rootfs

### DIFF
--- a/testing/vm/rootfs.py
+++ b/testing/vm/rootfs.py
@@ -97,6 +97,7 @@ def _build_rootfs(
 
     command = [
         "podman",
+        "--runtime=runc",
         "run",
         "--rm",
         "--mount",


### PR DESCRIPTION
Temporary CI experiment.

The LiteVM jobs intermittently fail before tests start because crun rejects the OCI version used by Podman. This branch selects runc for the rootfs build and changes only `testing/vm/rootfs.py`.

This PR is for checking the OL8, OL9, and OL10 jobs. Do not merge it yet.
