### PR TITLE
Fixes for UEK-NEXT (v7.1)

### DIFF
--- a/drgn_tools/ext4_dirlock.py
+++ b/drgn_tools/ext4_dirlock.py
@@ -97,8 +97,7 @@ from drgn_tools.bt import bt
 from drgn_tools.bt import bt_has
 from drgn_tools.corelens import CorelensModule
 from drgn_tools.itertools import count
-from drgn_tools.locking import for_each_mutex_waiter
-from drgn_tools.locking import for_each_rwsem_waiter
+from drgn_tools.locking import for_each_lock_waiter
 from drgn_tools.locking import show_lock_waiter
 from drgn_tools.module import ensure_debuginfo
 from drgn_tools.task import task_lastrun2now
@@ -175,15 +174,15 @@ def ext4_dirlock_scan(prog: drgn.Program, stacktrace: bool = False) -> None:
             bt(task)
         print("%-12s:" % "Lock waiter")
 
-        index = 0
         if has_member(inode, "i_rwsem"):
-            for waiter in for_each_rwsem_waiter(prog, inode.i_rwsem):
-                show_lock_waiter(prog, waiter, index, stacktrace)
-                index = index + 1
-        elif has_member(inode, "i_mutex"):
-            for waiter in for_each_mutex_waiter(prog, inode.i_mutex):
-                show_lock_waiter(prog, waiter, index, stacktrace)
-                index = index + 1
+            lock = inode.i_rwsem.address_of_()
+        else:
+            lock = inode.i_mutex.address_of_()
+
+        index = 0
+        for waiter in for_each_lock_waiter(lock):
+            show_lock_waiter(prog, waiter.task, index, stacktrace)
+            index = index + 1
 
 
 class Ext4DirLock(CorelensModule):

--- a/drgn_tools/file.py
+++ b/drgn_tools/file.py
@@ -24,6 +24,7 @@ from drgn.helpers.linux.xarray import xa_for_each
 from drgn_tools.corelens import CorelensModule
 from drgn_tools.table import print_table
 from drgn_tools.util import human_bytes
+from drgn_tools.util import type_has_member
 
 
 def for_each_inode_page_in_pagecache(
@@ -240,9 +241,15 @@ def __path_by_inode(inode: Object) -> str:
     hlist_head = inode.i_dentry
     if hlist_empty(hlist_head.address_of_()):
         return "[NO DENTRY]"
+    # Since v7.1 commit 2420067cecacb ("struct dentry: make ->d_u anonymous"),
+    # d_u no longer exists and the union is anonymous.
+    if type_has_member(inode.prog_, "struct dentry", "d_u"):
+        member = "d_u.d_alias"
+    else:
+        member = "d_alias"
     try:
         hlist_node = hlist_head.first
-        dentry = container_of(hlist_node, "struct dentry", "d_u")
+        dentry = container_of(hlist_node, "struct dentry", member)
         return d_path(dentry).decode()
     except drgn.FaultError:
         return "[ERROR]"

--- a/drgn_tools/lock.py
+++ b/drgn_tools/lock.py
@@ -47,8 +47,7 @@ from drgn_tools.deadlock import DependencyGraph
 from drgn_tools.locking import _RWSEM_READER_MASK
 from drgn_tools.locking import _RWSEM_READER_SHIFT
 from drgn_tools.locking import completion_for_each_task
-from drgn_tools.locking import for_each_mutex_waiter
-from drgn_tools.locking import for_each_rwsem_waiter
+from drgn_tools.locking import for_each_lock_waiter
 from drgn_tools.locking import get_lock_from_frame
 from drgn_tools.locking import get_rwsem_owner
 from drgn_tools.locking import get_rwsem_spinners_info
@@ -167,7 +166,8 @@ def get_mutex_lock_info(
         if pid is None:
             if time is None:
                 time = 0
-            for waiter in for_each_mutex_waiter(prog, mutex):
+            for waiter_obj in for_each_lock_waiter(mutex):
+                waiter = waiter_obj.task
                 waittime = task_lastrun2now(waiter)
                 timens = time * 1000000000
                 index = index + 1
@@ -245,7 +245,8 @@ def scan_mutex_lock(
         if pid is None:
             if time is None:
                 time = 0
-            for waiter in for_each_mutex_waiter(prog, mutex):
+            for waiter_obj in for_each_lock_waiter(mutex):
+                waiter = waiter_obj.task
                 waittime = task_lastrun2now(waiter)
                 timens = time * 1000000000
                 index = index + 1
@@ -293,7 +294,8 @@ def show_sem_lock(
         if pid is None:
             if time is None:
                 time = 0
-            for waiter in for_each_rwsem_waiter(prog, sem):
+            for waiter_obj in for_each_lock_waiter(sem):
+                waiter = waiter_obj.task
                 waittime = task_lastrun2now(waiter)
                 timens = time * 1000000000
                 index = index + 1
@@ -370,7 +372,8 @@ def show_rwsem_lock(
             if time is None:
                 time = 0
 
-            for waiter in for_each_rwsem_waiter(prog, rwsem):
+            for waiter_obj in for_each_lock_waiter(rwsem):
+                waiter = waiter_obj.task
                 waittime = task_lastrun2now(waiter)
                 timens = time * 1000000000
                 index = index + 1

--- a/drgn_tools/locking.py
+++ b/drgn_tools/locking.py
@@ -4,6 +4,7 @@
 Helper for linux kernel locking
 """
 import enum
+from typing import Callable
 from typing import Iterable
 from typing import Optional
 from typing import Tuple
@@ -17,6 +18,7 @@ from drgn import NULL
 from drgn import Object
 from drgn import Program
 from drgn import StackFrame
+from drgn import Type
 from drgn.helpers import ValidationError
 from drgn.helpers.linux.list import list_empty
 from drgn.helpers.linux.list import list_for_each_entry
@@ -32,6 +34,7 @@ from drgn_tools.mm import AddrKind
 from drgn_tools.table import FixedTable
 from drgn_tools.task import get_current_run_time
 from drgn_tools.task import task_lastrun2now
+from drgn_tools.util import has_member
 from drgn_tools.util import per_cpu_owner
 from drgn_tools.util import timestamp_str
 
@@ -206,75 +209,58 @@ def show_lock_waiter(
         print("")
 
 
-def for_each_rwsem_waiter(prog: Program, rwsem: Object) -> Iterable[Object]:
-    """
-    List task waiting on the rw semaphore
-
-    :param prog: drgn program
-    :param rwsem: ``struct rw_semaphore *``
-    :returns: ``struct task_struct *``
-    """
-    for waiter in list_for_each_entry(
-        prog.type("struct rwsem_waiter"), rwsem.wait_list.address_of_(), "list"
-    ):
-        yield waiter.task
+# Represents list_for_each_entry() or validate_list_for_each_entry()
+IterFn = Callable[[Type, Object, str], Iterable[Object]]
 
 
-def for_each_mutex_waiter(prog: Program, mutex: Object) -> Iterable[Object]:
-    """
-    List task waiting on the mutex
-
-    :param prog: drgn program
-    :param mutex: ``struct mutex *``
-    :returns: ``struct task_struct *``
-    """
-    for waiter in list_for_each_entry(
-        prog.type("struct mutex_waiter"), mutex.wait_list.address_of_(), "list"
-    ):
-        yield waiter.task
-
-
-def for_each_rwsem_waiter_careful(
-    prog: Program, rwsem: Object
+def for_each_lock_waiter(
+    lock: Object, iterfn: IterFn = list_for_each_entry
 ) -> Iterable[Object]:
     """
-    List task waiting on the rw semaphore
+    List tasks waiting on the semaphore, rwsem, or mutex
 
-    :param prog: drgn program
-    :param rwsem: ``struct rw_semaphore *``
-    :returns: ``struct task_struct *``
+    Since all three lock types share very similar waiter listing structures,
+    it's possible to implement this helper generically for all of them. In
+    addition, by providing an iterator function, we can also provide a
+    "validating" version of the iteration. This is necessary for us to scan lock
+    pointers in a stack.
+
+    :param lock: ``struct rw_semaphore *`` or ``struct mutex *``
+    :param iterfn: function used to iterate over the list. Use
+        validate_list_each_entry() to create a more careful version that doesn't
+        fall into cycles, useful for testing the hypothesis of whether a pointer
+        even is a mutex to begin with.
+    :returns: iterator of objects of the appropriate waiter type:
+        ``struct mutex_waiter *``, ``struct rwsem_waiter *``,  or
+        ``struct semaphore_waiter *``
     """
-    seen = set()
-    for waiter in validate_list_for_each_entry(
-        prog.type("struct rwsem_waiter"), rwsem.wait_list.address_of_(), "list"
-    ):
-        addr = waiter.value_()
-        if addr in seen:
-            raise ValidationError("circular list")
-        seen.add(addr)
-        yield waiter.task
+    prog = lock.prog_
+    if has_member(lock, "first_waiter"):
+        # Since the following v7.1 commits for semaphore, rwsem, and mutex, all
+        # part of the below series, the locks only store a pointer to the first
+        # waiter, rather than a full list_head.
+        #
+        # Series: https://lore.kernel.org/all/20260305195545.3707590-1-willy@infradead.org/
+        # 1ea4b473504b6 locking/rwsem: Remove the list_head from struct rw_semaphore
+        # b9bdd4b684045 locking/semaphore: Remove the list_head from struct semaphore
+        # 25500ba7e77ce locking/mutex: Remove the list_head from struct mutex
+        first = lock.first_waiter
+        if not first:
+            return
+        yield first
+        list_head = first.list.address_of_()
+        type_ = first.type_.type
+    else:
+        type_to_waiter = {
+            "mutex": "struct mutex_waiter",
+            "semaphore": "struct semaphore_waiter",
+            "rw_semaphore": "struct rwsem_waiter",
+        }
+        list_head = lock.wait_list.address_of_()
+        type_ = prog.type(type_to_waiter[lock.type_.type.tag])
 
-
-def for_each_mutex_waiter_careful(
-    prog: Program,
-    mutex: Object,
-) -> Iterable[Object]:
-    """
-    List task waiting on the mutex
-
-    :param prog: drgn program
-    :param mutex: ``struct mutex *``
-    :returns: ``struct task_struct *``
-    """
-    seen = set()
-    for waiter in validate_list_for_each_entry(
-        prog.type("struct mutex_waiter"), mutex.wait_list.address_of_(), "list"
-    ):
-        addr = waiter.value_()
-        if addr in seen:
-            raise ValidationError("circular list")
-        seen.add(addr)
-        yield waiter.task
+    for waiter in iterfn(type_, list_head, "list"):
+        yield waiter
 
 
 ######################################
@@ -323,20 +309,6 @@ def rwsem_has_spinner(rwsem: Object) -> bool:
     :returns: True if rwsem has optimistic spinners, False otherwise.
     """
     return osq_is_locked(rwsem.osq.address_of_())
-
-
-def for_each_rwsem_waiter_entity(rwsem: Object) -> Iterable[Object]:
-    """
-    Find rwsem_waiter(s) for given rwsem
-
-    :param rwsem: ``struct rw_semaphore *``
-    :returns: Iterator of ``struct rwsem_waiter``
-    """
-
-    for waiter in list_for_each_entry(
-        "struct rwsem_waiter", rwsem.wait_list.address_of_(), "list"
-    ):
-        yield waiter
 
 
 def rwsem_count(rwsem: Object) -> int:
@@ -418,7 +390,7 @@ def get_rwsem_waiters_info(rwsem: Object, callstack: int = 0) -> None:
     waiter_type = "none"
     print("The waiters of rwsem are as follows: ")
     tbl = FixedTable(["TASK:>x", "PID:>", "TYPE:16s", "CPU:>", "ST", "WAIT:>"])
-    for waiter in for_each_rwsem_waiter_entity(rwsem):
+    for waiter in for_each_lock_waiter(rwsem):
         waiter_type = get_rwsem_waiter_type(waiter)
         task = waiter.task
         tbl.row(
@@ -597,15 +569,12 @@ def is_task_blocked_on_lock(
     """
 
     try:
-        if lock_type == "semaphore" or lock_type == "rw_semaphore":
+        if lock_type in ("mutex", "semaphore", "rw_semaphore"):
             return pid in [
-                waiter.pid.value_()
-                for waiter in for_each_rwsem_waiter_careful(lock.prog_, lock)
-            ]
-        elif lock_type == "mutex":
-            return pid in [
-                waiter.pid.value_()
-                for waiter in for_each_mutex_waiter_careful(lock.prog_, lock)
+                waiter.task.pid.value_()
+                for waiter in for_each_lock_waiter(
+                    lock, validate_list_for_each_entry
+                )
             ]
         elif lock_type == "completion":
             return pid in [

--- a/drgn_tools/meminfo.py
+++ b/drgn_tools/meminfo.py
@@ -508,6 +508,8 @@ def get_all_meminfo(prog: Program) -> Dict[str, int]:
 
     stats["KernelStack"] = global_stats["NR_KERNEL_STACK_KB"]
     stats["PageTables"] = global_stats["NR_PAGETABLE"]
+    if "NR_SECONDARY_PAGETABLE" in global_stats:
+        stats["SecPageTables"] = global_stats["NR_SECONDARY_PAGETABLE"]
     stats["NFS_Unstable"] = 0
     if "NR_UNSTABLE_NFS" in global_stats:
         stats["NFS_Unstable"] = global_stats["NR_UNSTABLE_NFS"]
@@ -576,6 +578,14 @@ def get_all_meminfo(prog: Program) -> Dict[str, int]:
     if b"CMA" in migratetype_names:
         stats["CmaTotal"] = prog["totalcma_pages"].value_()
         stats["CmaFree"] = global_stats["NR_FREE_CMA_PAGES"]
+
+    if "NR_UNACCEPTED" in global_stats:
+        stats["Unaccepted"] = global_stats["NR_UNACCEPTED"]
+    if "NR_BALLOON_PAGES" in global_stats:
+        stats["Balloon"] = global_stats["NR_BALLOON_PAGES"]
+    if "NR_GPU_ACTIVE" in global_stats:
+        stats["GPUActive"] = global_stats["NR_GPU_ACTIVE"]
+        stats["GPUReclaim"] = global_stats["NR_GPU_RECLAIM"]
     return stats
 
 
@@ -616,6 +626,7 @@ def show_all_meminfo(prog: Program) -> None:
         "SUnreclaim",
         "KernelStack",
         "PageTables",
+        "SecPageTables",
         "NFS_Unstable",
         "Bounce",
         "WritebackTmp",
@@ -626,18 +637,23 @@ def show_all_meminfo(prog: Program) -> None:
         "VmallocChunk",
         "Percpu",
         "HardwareCorrupted",
-    ]
-    hugepage_meminfo_items = [
         "AnonHugePages",
         "ShmemHugePages",
         "ShmemPmdMapped",
         "FileHugePages",
         "FilePmdMapped",
+        "CmaTotal",
+        "CmaFree",
+        "Unaccepted",
+        "Balloon",
+        "GPUActive",
+        "GPUReclaim",
     ]
-    cma_meminfo_items = ["CmaTotal", "CmaFree"]
 
     # Output
     for item in basic_meminfo_items:
+        if item not in stats:
+            continue
         if stats[item] == -1:
             continue
 
@@ -651,12 +667,6 @@ def show_all_meminfo(prog: Program) -> None:
             else:
                 print(f"{item + ':': <15} {num_str: >8} kB")
         else:
-            print_val_kb(prog, item, stats[item])
-
-    for item in hugepage_meminfo_items:
-        print_val_kb(prog, item, stats[item])
-    for item in cma_meminfo_items:
-        if item in stats:
             print_val_kb(prog, item, stats[item])
 
     # Report hugepage related meminfo

--- a/drgn_tools/module.py
+++ b/drgn_tools/module.py
@@ -224,7 +224,11 @@ def module_exports(module: Object) -> List[Tuple[int, str]]:
                 )
 
     add_symbols(module.num_syms, module.syms)
-    add_symbols(module.num_gpl_syms, module.gpl_syms)
+    # Since v7.1 commit b4760ff2a5e43 ("module: deprecate usage of *_gpl
+    # sections in module loader"), GPL symbols are no longer in a separate
+    # section and thus have no separate fields.
+    if hasattr(module, "num_gpl_syms"):
+        add_symbols(module.num_gpl_syms, module.gpl_syms)
     if hasattr(module, "unused_syms"):
         add_symbols(module.num_unused_syms, module.unused_syms)
     if hasattr(module, "unused_gpl_syms"):

--- a/drgn_tools/numastat.py
+++ b/drgn_tools/numastat.py
@@ -185,6 +185,12 @@ def get_per_node_meminfo(prog: Program, node: Object) -> Dict[str, int]:
     if "NR_UNACCEPTED" in node_zone_stats:
         mm_stats["Unaccepted"] = node_zone_stats["NR_UNACCEPTED"]
 
+    # Since v7.1 commit 2232ba9c7931d ("mm: add gpu active/reclaim per-node stat
+    # counters (v2)")
+    if "NR_GPU_ACTIVE" in node_zone_stats:
+        mm_stats["GPUActive"] = node_zone_stats["NR_GPU_ACTIVE"]
+        mm_stats["GPUReclaim"] = node_zone_stats["NR_GPU_RECLAIM"]
+
     # Collect hugepage info for the default hugepage size in this node.
     node_id = node.node_id.value_()
     hstate = prog["hstates"][prog["default_hstate_idx"]]

--- a/drgn_tools/slabinfo.py
+++ b/drgn_tools/slabinfo.py
@@ -30,6 +30,7 @@ from drgn.helpers.linux.slab import slab_cache_for_each_allocated_object
 
 from drgn_tools.corelens import CorelensModule
 from drgn_tools.table import FixedTable
+from drgn_tools.util import has_member
 from drgn_tools.util import hexdump_mem
 
 
@@ -133,11 +134,18 @@ def _kmem_cache_barn_free_objs(cache: Object) -> int:
 
     total = 0
     for nodeid in for_each_online_node(prog):
-        node = cache.node[nodeid]
-        try:
-            barn = node.barn
-        except AttributeError:
-            return 0
+        if has_member(cache, "per_node"):
+            # In v7.1 commit 5ba6bc27b1f99 ("slab: decouple pointer to barn from
+            # kmem_cache_node"), the barn pointer is moved from the
+            # kmem_cache_node object, to a pointer in the "per_node" field of
+            # the slab cache. But
+            barn = cache.per_node[nodeid].barn
+        else:
+            node = cache.node[nodeid]
+            try:
+                barn = node.barn
+            except AttributeError:
+                return 0
         if not barn:
             continue
         for sheaf in list_for_each_entry(
@@ -168,7 +176,13 @@ def kmem_cache_pernode(
     nr_partial = 0
     node_total_use = 0
 
-    kmem_cache_node = cache.node[nodeid]
+    if has_member(cache, "per_node"):
+        # In v7.1 commit 5ba6bc27b1f99 ("slab: decouple pointer to barn from
+        # kmem_cache_node"), the node pointer is moved to within the per_node
+        # array.
+        kmem_cache_node = cache.per_node[nodeid].node
+    else:
+        kmem_cache_node = cache.node[nodeid]
     x = 0
 
     prog = cache.prog_

--- a/testing/vm/config.py
+++ b/testing/vm/config.py
@@ -126,10 +126,16 @@ class VmLayout(NamedTuple):
 
 
 TARGETS = [
-    KernelCategory(10, KernelKind.UEKNEXT, "x86_64"),
+    # Skip UEK-NEXT (v7.1) due to two errors:
+    # -> 'struct kmem_cache' has no member 'node'
+    # -> unrecognized .orc_header
+    # Both are fixed in drgn 0.2.0, but until it is released to Oracle Linux
+    # RPMs we cannot run it in the test suite.
+    # TODO: Enable UEK-NEXT testing once drgn 0.2.0 is released on OL.
+    # KernelCategory(10, KernelKind.UEKNEXT, "x86_64"),
     KernelCategory(10, KernelKind.UEK8, "x86_64"),
     KernelCategory(10, KernelKind.RHCK, "x86_64"),
-    KernelCategory(9, KernelKind.UEKNEXT, "x86_64"),
+    # KernelCategory(9, KernelKind.UEKNEXT, "x86_64"),
     KernelCategory(9, KernelKind.UEK8, "x86_64"),
     KernelCategory(9, KernelKind.UEK7, "x86_64"),
     KernelCategory(9, KernelKind.RHCK, "x86_64"),


### PR DESCRIPTION
Fixes for 5 changes in UEK-NEXT:
- slab: `kmem_cache.node` is now `kmem_cache.per_node[i].node`, and the per-node barn is on the `per_node` object.
- locking: handle a [series](https://lore.kernel.org/all/20260305195545.3707590-1-willy@infradead.org/) that reduces the size of locks by removing the list_head.
- filecache: the `d_u` union became anonymous on `struct dentry`.
- module: GPL syms are removed
- meminfo / numastat: added new stats (GPUActive, GPUReclaim), plus making sure a few others get plumbed through to the corelens output

Finally, the last commit skips UEK-NEXT testing until drgn 0.2.0. There are two other issues (one related to slab, one related to ORC stack unwinding) that cannot be fixed without drgn 0.2.0. I've installed the RPMs locally and verified the test suite passes with 0.2.0 on UEK-NEXT. But until we have the RPMs released publicly we need to disable the UEK-NEXT tests in Github.